### PR TITLE
Remove arbitrary-dimension lattices and systems

### DIFF
--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -180,7 +180,7 @@ meas_rate = 40     # Number of timesteps between snapshots of LLD to input to FF
                    # The maximum frequency we resolve is set by 2π/(meas_rate * Δt)
 dyn_meas = 400     # Total number of frequencies we'd like to resolve
 dynsf = dynamic_structure_factor(
-    sys, sampler; therm_samples=10, dynΔt=Δt, meas_rate=meas_rate,
+    sys, sampler; nsamples=10, dynΔt=Δt, meas_rate=meas_rate,
     dyn_meas=dyn_meas, bz_size=(1,1,2), thermalize=10, verbose=true,
     reduce_basis=true, dipole_factor=false,
 )
@@ -325,7 +325,7 @@ meas_rate = convert(Int, div(2π, (2 * target_max_ω * Δt)))
 sampler = MetropolisSampler(system, kT, 500)
 println("Starting structure factor measurement...")
 dynsf = dynamic_structure_factor(
-    system, sampler; therm_samples=15, thermalize=15,
+    system, sampler; nsamples=15, thermalize=15,
     bz_size=(2,0,0), reduce_basis=true, dipole_factor=true,
     dynΔt=Δt, meas_rate=meas_rate, dyn_meas=1000, verbose=true, 
 )
@@ -496,7 +496,6 @@ To discover the symmetry allowed couplings for all bonds up to a certain
 distance, we can use the function [`print_bond_table`](@ref).
 
 ```
-lat_vecs = lattice_vectors(1, 1, 1, 90, 90, 90)
 crystal = Sunny.diamond_crystal()
 print_bond_table(crystal, 1.0)
 ```
@@ -548,7 +547,7 @@ find the ones starting from atom 2 we can use
 ```
 julia> all_symmetry_related_bonds_for_atom(crystal, 2, Bond(2, 3, [0, 0, 0]))
 
-4-element Vector{Bond{3}}:
+4-element Vector{Bond}:
  Bond(2, 7, [0, 0, -1])
  Bond(2, 8, [0, 0, -1])
  Bond(2, 3, [0, 0, 0])
@@ -563,8 +562,8 @@ julia> print_bond(crystal, Bond(1, 6, [1,-1,0]))
 Bond(1, 6, [1, -1, 0])
 Distance 1.225, coordination 24
 Connects [0, 0, 0] to [1, -0.5, 0.5]
-Allowed exchange matrix: |   A  D+E -D-E |
-                         | D-E    B    C |
-                         |-D+E    C    B |
-Allowed DM vector: [0 E E]
+Allowed exchange matrix: |   A  D-E -D+E |
+                         | D+E    B    C |
+                         |-D-E    C    B |
+Allowed DM vector: [0 -E -E]
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -14,10 +14,10 @@ This is the documentation for [Sunny.jl](https://github.com/MagSims/Sunny.jl). T
 - Structure factor calculations
 - Automated symmetry analysis and bond equivalency class discovery
 - Interactive plotting using [Makie.jl](https://github.com/JuliaPlots/Makie.jl)
+- Parallel tempering
 
 **Planned Features**
 - CPU parallelization of dynamics and Monte Carlo simulations
-- Parallel tempering
 - Generalized ``\mathrm{SU(N)}`` models
 - GPU acceleration
 - Accelerated local MC updates in the presence of long-range dipole interactions

--- a/examples/PT_afm_diamond.jl
+++ b/examples/PT_afm_diamond.jl
@@ -12,7 +12,7 @@ crystal = Sunny.diamond_crystal()
 # interactions -- units of K  
 J = 28.28
 interactions = [
-    heisenberg(J, Bond{3}(1, 3, [0,0,0])),
+    heisenberg(J, Bond(1, 3, [0,0,0])),
 ]
 
 # spin system -- setup to use K

--- a/src/Ewald.jl
+++ b/src/Ewald.jl
@@ -17,7 +17,7 @@ Specifically, computes:
       - \frac{π}{2Vη^2}Q^2 - \frac{η}{\sqrt{π}} \sum_{i} q_i^2
 ```
 """
-function ewald_sum_monopole(lattice::Lattice{3}, charges::Array{Float64, 4}; η=1.0, extent=5) :: Float64
+function ewald_sum_monopole(lattice::Lattice, charges::Array{Float64, 4}; η=1.0, extent=5) :: Float64
     extent_idxs = CartesianIndices((-extent:extent, -extent:extent, -extent:extent))
 
     recip = gen_reciprocal(lattice)
@@ -80,7 +80,7 @@ function ewald_sum_monopole(lattice::Lattice{3}, charges::Array{Float64, 4}; η=
     return 0.5 * real_space_sum + 2π / vol * real(recip_space_sum) + tot_charge_term + charge_square_term
 end
 
-function direct_sum_monopole(lattice::Lattice{3}, charges::Array{Float64, 4}; s=0.0, extent=5) :: Float64
+function direct_sum_monopole(lattice::Lattice, charges::Array{Float64, 4}; s=0.0, extent=5) :: Float64
     extent_idxs = CartesianIndices((-extent:extent, -extent:extent, -extent:extent))
 
     # Vectors spanning the axes of the entire system
@@ -128,7 +128,7 @@ end
 Performs ewald summation to calculate the potential energy of a 
 system of dipoles with periodic boundary conditions.
 """
-function ewald_sum_dipole(lattice::Lattice{3}, spins::Array{Vec3, 4}; extent=2, η=1.0) :: Float64
+function ewald_sum_dipole(lattice::Lattice, spins::Array{Vec3, 4}; extent=2, η=1.0) :: Float64
     extent_idxs = CartesianIndices((-extent:extent, -extent:extent, -extent:extent))
 
     # Vectors spanning the axes of the entire system
@@ -204,7 +204,7 @@ function ewald_sum_dipole(lattice::Lattice{3}, spins::Array{Vec3, 4}; extent=2, 
 end
 
 "Precompute the dipole interaction matrix, not yet in ± compressed form."
-function precompute_monopole_ewald(lattice::Lattice{3}; extent=10, η=1.0) :: OffsetArray{5, Float64} where {D}
+function precompute_monopole_ewald(lattice::Lattice; extent=10, η=1.0) :: OffsetArray{5, Float64} where {D}
     nb = nbasis(lattice)
     A = zeros(Float64, nb, nb, map(n->2*(n-1)+1, lattice.size)...)
     A = OffsetArray(A, 1:nb, 1:nb, map(n->-(n-1):n-1, lattice.size)...)
@@ -293,7 +293,7 @@ function contract_monopole(charges::Array{Float64, 4}, A::OffsetArray{Float64}) 
 end
 
 "Precompute the dipole interaction matrix, in ± compressed form."
-function precompute_dipole_ewald(lattice::Lattice{3}; extent=3, η=1.0) :: OffsetArray{Mat3, 5}
+function precompute_dipole_ewald(lattice::Lattice; extent=3, η=1.0) :: OffsetArray{Mat3, 5}
     nb = nbasis(lattice)
     A = zeros(Mat3, nb, nb, lattice.size...)
     A = OffsetArray(A, 1:nb, 1:nb, map(n->0:n-1, lattice.size)...)

--- a/src/Hamiltonian.jl
+++ b/src/Hamiltonian.jl
@@ -2,15 +2,6 @@
 # interaction types and orchestrates energy/field calculations.
 
 function validate_and_clean_interactions(ints::Vector{<:Interaction}, crystal::Crystal, latsize::Vector{Int64})
-    # Convert every OnSiteQuadratic to QuadraticInteraction
-    ints = map(ints) do int
-        if isa(int, OnSiteQuadratic)
-            return QuadraticInteraction(int.J, Bond(int.site, int.site, zeros(3)), int.label)
-        else
-            return int
-        end
-    end
-
     # Validate all interactions
     for int in ints
         if isa(int, QuadraticInteraction)

--- a/src/Hamiltonian.jl
+++ b/src/Hamiltonian.jl
@@ -1,15 +1,11 @@
 # Functions associated with HamiltonianCPU, which maintains the actual internal
 # interaction types and orchestrates energy/field calculations.
 
-
 function validate_and_clean_interactions(ints::Vector{<:Interaction}, crystal::Crystal, latsize::Vector{Int64})
-    D = dimension(crystal)
-
-    # Now that we know dimension D, we can convert every OnSiteQuadratic to
-    # QuadraticInteraction
+    # Convert every OnSiteQuadratic to QuadraticInteraction
     ints = map(ints) do int
         if isa(int, OnSiteQuadratic)
-            return QuadraticInteraction(int.J, Bond{D}(int.site, int.site, zeros(D)), int.label)
+            return QuadraticInteraction(int.J, Bond(int.site, int.site, zeros(3)), int.label)
         else
             return int
         end
@@ -19,11 +15,6 @@ function validate_and_clean_interactions(ints::Vector{<:Interaction}, crystal::C
     for int in ints
         if isa(int, QuadraticInteraction)
             b = int.bond
-
-            # Verify that the dimension is correct
-            if length(b.n) != D
-                error("Interaction $(repr(MIME("text/plain"), int)) inconsistent with crystal dimension $D.")
-            end
 
             # Verify that both basis sites indexed actually exist
             if !(1 <= b.i <= nbasis(crystal)) || !(1 <= b.j <= nbasis(crystal))
@@ -52,11 +43,6 @@ function validate_and_clean_interactions(ints::Vector{<:Interaction}, crystal::C
                 println("Distance-violating interaction: $int.")
                 error("Interaction wraps system.")
             end
-
-        elseif isa(int, DipoleDipole)
-            if D != 3
-                error("Dipole-dipole interactions require three dimensions.")
-            end
         end
     end
 
@@ -65,16 +51,16 @@ end
 
 
 """
-    HamiltonianCPU{D}
+    HamiltonianCPU
 
 Stores and orchestrates the types that perform the actual implementations
 of all interactions internally.
 """
-struct HamiltonianCPU{D}
+struct HamiltonianCPU
     ext_field   :: Union{Nothing, ExternalFieldCPU}
-    heisenbergs :: Vector{HeisenbergCPU{D}}
-    diag_coups  :: Vector{DiagonalCouplingCPU{D}}
-    gen_coups   :: Vector{GeneralCouplingCPU{D}}
+    heisenbergs :: Vector{HeisenbergCPU}
+    diag_coups  :: Vector{DiagonalCouplingCPU}
+    gen_coups   :: Vector{GeneralCouplingCPU}
     dipole_int  :: Union{Nothing, DipoleRealCPU, DipoleFourierCPU}
     spin_mags   :: Vector{Float64}
 end
@@ -82,7 +68,7 @@ end
 """
     HamiltonianCPU(ints::Vector{<:Interaction}, crystal, latsize, sites_info::Vector{SiteInfo})
 
-Construct a `HamiltonianCPU{3}` from a list of interactions, converting
+Construct a `HamiltonianCPU` from a list of interactions, converting
 each of the interactions into the proper backend type specialized
 for the given `crystal` and `latsize`.
 
@@ -92,9 +78,9 @@ function HamiltonianCPU(ints::Vector{<:Interaction}, crystal::Crystal,
                         latsize::Vector{Int64}, sites_info::Vector{SiteInfo};
                         μB=BOHR_MAGNETON::Float64, μ0=VACUUM_PERM::Float64)
     ext_field   = nothing
-    heisenbergs = Vector{HeisenbergCPU{3}}()
-    diag_coups  = Vector{DiagonalCouplingCPU{3}}()
-    gen_coups   = Vector{GeneralCouplingCPU{3}}()
+    heisenbergs = Vector{HeisenbergCPU}()
+    diag_coups  = Vector{DiagonalCouplingCPU}()
+    gen_coups   = Vector{GeneralCouplingCPU}()
     dipole_int  = nothing
     spin_mags   = [site.S for site in sites_info]
 
@@ -128,7 +114,7 @@ function HamiltonianCPU(ints::Vector{<:Interaction}, crystal::Crystal,
         end
     end
 
-    return HamiltonianCPU{3}(
+    return HamiltonianCPU(
         ext_field, heisenbergs, diag_coups, gen_coups, dipole_int, spin_mags
     )
 end
@@ -167,7 +153,7 @@ Note that all `_accum_neggrad!` functions should return _just_ the
 this function. Likewise, all code which utilizes local fields should
 be calling _this_ function, not the `_accum_neggrad!`'s directly.
 """
-function field!(B::Array{Vec3}, spins::Array{Vec3}, ℋ::HamiltonianCPU{D}) where {D}
+function field!(B::Array{Vec3}, spins::Array{Vec3}, ℋ::HamiltonianCPU)
     fill!(B, SA[0.0, 0.0, 0.0])
     if !isnothing(ℋ.ext_field)
         _accum_neggrad!(B, ℋ.ext_field)

--- a/src/Interactions.jl
+++ b/src/Interactions.jl
@@ -6,9 +6,9 @@ abstract type InteractionCPU end   # Subtype this for actual internal CPU implem
 abstract type InteractionGPU end   # Subtype this for actual internal GPU implementations
 
 
-struct QuadraticInteraction{D} <: Interaction
+struct QuadraticInteraction <: Interaction
     J     :: Mat3
-    bond  :: Bond{D}
+    bond  :: Bond
     label :: String
 end
 
@@ -270,7 +270,7 @@ function ExternalFieldCPU(ext_field::ExternalField, sites_info::Vector{SiteInfo}
     ExternalFieldCPU(effBs)
 end
 
-function energy(spins::Array{Vec3}, field::ExternalFieldCPU)
+function energy(spins::Array{Vec3, 4}, field::ExternalFieldCPU)
     E = 0.0
     for b in 1:size(spins, 1)
         effB = field.effBs[b]
@@ -282,7 +282,7 @@ function energy(spins::Array{Vec3}, field::ExternalFieldCPU)
 end
 
 "Accumulates the negative local Hamiltonian gradient coming from the external field"
-@inline function _accum_neggrad!(B::Array{Vec3}, field::ExternalFieldCPU)
+@inline function _accum_neggrad!(B::Array{Vec3, 4}, field::ExternalFieldCPU)
     for b in 1:size(B, 1)
         effB = field.effBs[b]
         for idx in CartesianIndices(size(B)[2:end])

--- a/src/Interactions.jl
+++ b/src/Interactions.jl
@@ -12,16 +12,6 @@ struct QuadraticInteraction <: Interaction
     label :: String
 end
 
-# A special case of QuadraticInteraction. Ideally we would never need this type,
-# but sometimes we don't know the dimension D at construction time. As soon as
-# knowledge of D becomes available (through a SpinSystem), every OnSiteQuadratic
-# is converted to QuadraticInteraction{D}.
-struct OnSiteQuadratic <: Interaction
-    J     :: Mat3
-    site  :: Int
-    label :: String
-end
-
 struct ExternalField <: Interaction
     B :: Vec3
 end
@@ -49,44 +39,35 @@ end
 SiteInfo(site::Int, S, g::Number) = SiteInfo(site, S, Mat3(g * I))
 SiteInfo(site::Int, S) = SiteInfo(site, S, 2.0)
 
-
-function Base.show(io::IO, ::MIME"text/plain", int::OnSiteQuadratic)
-    J = int.J
-    @assert J ≈ J'
-
-    # Check if it is easy-axis or easy-plane
-    λ, V = eigen(J)
-    nonzero_λ = findall(x -> abs(x) > 1e-12, λ)
-    if length(nonzero_λ) == 1
-        i = nonzero_λ[1]
-        dir = V[:, i]
-        if count(<(0.0), dir) >= 2
-            dir = -dir
-        end
-        name, D = λ[i] < 0 ? ("easy_axis", -λ[i]) : ("easy_plane", λ[i])
-        @printf io "%s(%.4g, [%.4g, %.4g, %.4g], %d)" name D dir[1] dir[2] dir[3] int.site
-    else
-        @printf io "single_ion_anisotropy([%.4g %.4g %.4g; %.4g %.4g %.4g; %.4g %.4g %.4g], %d)" J[1,1] J[1,2] J[1,3] J[2,1] J[2,2] J[2,3] J[3,1] J[3,2] J[3,3] int.site
-    end
-end
-
 function Base.show(io::IO, mime::MIME"text/plain", int::QuadraticInteraction)
-    if int.bond.i == int.bond.j && iszero(int.bond.n)
-        return show(io, mime, OnSiteQuadratic(int.J, int.bond.i, int.label))
-    end
-
     b = repr(mime, int.bond)
     J = int.J
-    if J ≈ -J'
+    if int.bond.i == int.bond.j && iszero(int.bond.n)  # Catch on-site anisotropies
+        @assert J ≈ J'
+        # Check if it is easy-axis or easy-plane
+        λ, V = eigen(J)
+        nonzero_λ = findall(x -> abs(x) > 1e-12, λ)
+        if length(nonzero_λ) == 1
+            i = nonzero_λ[1]
+            dir = V[:, i]
+            if count(<(0.0), dir) >= 2
+                dir = -dir
+            end
+            name, D = λ[i] < 0 ? ("easy_axis", -λ[i]) : ("easy_plane", λ[i])
+            @printf io "%s(%.4g, [%.4g, %.4g, %.4g], %d)" name D dir[1] dir[2] dir[3] int.bond.i
+        else
+            @printf io "single_ion_anisotropy([%.4g %.4g %.4g; %.4g %.4g %.4g; %.4g %.4g %.4g], %d)" J[1,1] J[1,2] J[1,3] J[2,1] J[2,2] J[2,3] J[3,1] J[3,2] J[3,3] int.bond.i
+        end
+    elseif J ≈ -J'                         # Catch purely DM interactions
         x = J[2, 3]
         y = J[3, 1]
         z = J[1, 2]
         @printf io "dm_interaction([%.4g, %.4g, %.4g], %s)" x y z b
-    elseif diagm(fill(J[1,1], 3)) ≈ J
+    elseif diagm(fill(J[1,1], 3)) ≈ J      # Catch Heisenberg interactions
         @printf io "heisenberg(%.4g, %s)" J[1,1] b
-    elseif diagm(diag(J )) ≈ J
+    elseif diagm(diag(J)) ≈ J              # Catch diagonal interactions
         @printf io "exchange(diagm([%.4g, %.4g, %.4g]), %s)" J[1,1] J[2,2] J[3,3] b
-    else
+    else                                   # Rest -- general exchange interactions
         @printf io "exchange([%.4g %.4g %.4g; %.4g %.4g %.4g; %.4g %.4g %.4g], %s)" J[1,1] J[1,2] J[1,3] J[2,1] J[2,2] J[2,3] J[3,1] J[3,2] J[3,3] b
         # TODO: Figure out how to reenable this depending on context:
         # @printf io "exchange([%.4f %.4f %.4f\n"   J[1,1] J[1,2] J[1,3]
@@ -161,7 +142,7 @@ function single_ion_anisotropy(J, site::Int, label::String="Anisotropy")
     if !(J ≈ J')
         error("Single-ion anisotropy must be symmetric.")
     end
-    OnSiteQuadratic(Mat3(J), site, label)
+    QuadraticInteraction(Mat3(J), Bond(site, site, [0,0,0]), label)
 end
 
 
@@ -183,7 +164,7 @@ function easy_axis(D, n, site::Int, label::String="EasyAxis")
     if !(norm(n) ≈ 1)
         error("Parameter `n` must be a unit vector. Consider using `normalize(n)`.")
     end
-    OnSiteQuadratic(-D*Mat3(n*n'), site, label)
+    QuadraticInteraction(-D*Mat3(n*n'), Bond(site, site, [0,0,0]), label)
 end
 
 
@@ -205,7 +186,7 @@ function easy_plane(D, n, site::Int, label::String="EasyAxis")
     if !(norm(n) ≈ 1)
         error("Parameter `n` must be a unit vector. Consider using `normalize(n)`.")
     end
-    OnSiteQuadratic(+D*Mat3(n*n'), site, label)
+    QuadraticInteraction(+D*Mat3(n*n'), Bond(site, site, [0,0,0]), label)
 end
 
 

--- a/src/Lattice.jl
+++ b/src/Lattice.jl
@@ -5,61 +5,43 @@
 """
 
 """
-    Lattice{D, L, Db}
+    Lattice
 
-A type holding geometry information about a lattice in a simulation box.
-The type parameter `D` represents the dimensionality of the `Lattice`,
- while the others must satisfy `L = D^2, Db = D + 1`.
-
-These other type parameters must be in the definition for technical reasons,
- but can be inferred without needing them explicitly provided. For example,
- see the `Lattice{D}` constructor.
+A type holding geometry information about a 3D lattice in a simulation box.
 """
-struct Lattice{D, L, Db} <: AbstractArray{SVector{D, Float64}, Db}
-    lat_vecs      :: SMatrix{D, D, Float64, L}       # Columns are lattice vectors
-    basis_vecs    :: Vector{SVector{D, Float64}}     # Each SVector gives a basis vector
+struct Lattice <: AbstractArray{SVector{3, Float64}, 4}
+    lat_vecs      :: SMatrix{3, 3, Float64, 9}       # Columns are lattice vectors
+    basis_vecs    :: Vector{SVector{3, Float64}}     # Each SVector gives a basis vector
     types         :: Vector{String}                  # Indices labeling atom types
-    size          :: SVector{D, Int}                 # Number of cells along each dimension
+    size          :: SVector{3, Int}                 # Number of cells along each dimension
 
     @doc """
-        Lattice{D}(lat_vecs, basis_vecs, types, latsize)
+        Lattice(lat_vecs, basis_vecs, types, latsize)
 
-    Construct a `D`-dimensional `Lattice`.
+    Construct a 3-dimensional `Lattice`.
     # Arguments
     - `lat_vecs`: A matrix where the lattice vectors form the columns.
-                  Must be `convert`-able into `SMatrix{D, D, Float64, D^2}`.
+                  Must be `convert`-able into `SMatrix{3, 3, Float64, 9}`.
     - `basis_vecs`: A `Vector` of basis positions of sites within the unit cell,
                      given in fractional coordinates.
-                    Each element must be `convert`-able into `SVector{D, Float64}`.
+                    Each element must be `convert`-able into `SVector{3, Float64}`.
     - `types::Vector{String}`: A list of atomic types identifiers for each site.
                                  Equivalent sites should have the same identifier.
     - `latsize`: Specifies the number of unit cells extending along each lattice vector.
-                 Must be `convert`-able into `SVector{D, Int}`.
+                 Must be `convert`-able into `SVector{3, Int}`.
     """
-    function Lattice{D}(lat_vecs, basis_vecs, types, latsize) where {D}
-        @assert all(isequal(D), size(lat_vecs))          "All dims of lat_vecs should be equal size"
-        @assert all(isequal(D), map(length, basis_vecs)) "All basis_vecs should be size $D to match lat_vecs"
+    function Lattice(lat_vecs, basis_vecs, types, latsize)
+        @assert all(isequal(3), size(lat_vecs))          "All `lat_vecs` dims must be length 3"
+        @assert all(isequal(3), map(length, basis_vecs)) "All basis_vecs should be length 3 to match lat_vecs"
         @assert length(basis_vecs) > 0                   "At least one basis atom required"
         @assert length(basis_vecs) == length(types)      "Length of basis_vecs and types should match"
         @assert all(v->all(0 .<= v .< 1), basis_vecs)    "All basis_vecs should be given in fractional coordinates [0, 1)"
-        @assert length(latsize) == D                     "latsize should be size $D to match lat_vecs"
-        lat_vecs = convert(SMatrix{D, D}, lat_vecs)
-        basis_vecs = [lat_vecs * convert(SVector{D, Float64}, b) for b in basis_vecs]
-        latsize = SVector{D, Int}(latsize)
-        new{D, D*D, D+1}(lat_vecs, basis_vecs, types, latsize)
+        @assert length(latsize) == 3                     "latsize should be length 3"
+        lat_vecs = convert(SMatrix{3, 3, Float64, 9}, lat_vecs)
+        basis_vecs = [lat_vecs * convert(SVector{3, Float64}, b) for b in basis_vecs]
+        latsize = SVector{3, Int}(latsize)
+        new(lat_vecs, basis_vecs, types, latsize)
     end
-end
-
-"""
-    Lattice(lat_vecs, basis_vecs, types, latsize)
-
-Construct a `Lattice`, with the dimension inferred by the shape of `lat_vecs`.
-"""
-function Lattice(lat_vecs, basis_vecs, types, latsize)
-    D = size(lat_vecs, 1)
-    return Lattice{D}(
-        lat_vecs, basis_vecs, types, latsize
-    )
 end
 
 """
@@ -68,20 +50,14 @@ end
 Construct a `Lattice`, with the dimension inferred by the shape of `lat_vecs`,
 and all sites assumed to be the same type (labeled `"A"`).
 """
-function Lattice(lat_vecs, basis_vecs, latsize)
-    D = size(lat_vecs, 1)
-    return Lattice{D}(
-        lat_vecs, basis_vecs, fill("A", length(basis_vecs)), latsize
-    )
-end
+Lattice(lvecs, bvecs, latsize) = Lattice(lvecs, bvecs, fill("A", length(bvecs)), latsize)
 
 """
-    lattice_params(lattice::Lattice{3})
+    lattice_params(lattice::Lattice)
 """
 
 function Base.show(io::IO, ::MIME"text/plain", lattice::Lattice)
-    D = length(size(lattice)) - 1
-    println(io, join(size(lattice), "x"), " Lattice{$D}")
+    println(io, join(size(lattice), "x"), " Lattice")
     # Print out lattice vectors, types, basis?
 end
 
@@ -92,31 +68,15 @@ end
 
 Construct a `Crystal` using geometry information in `lattice`, inferring symmetry information.
 """
-function Crystal(lattice::Lattice{3, 9, 4})
+function Crystal(lattice::Lattice)
     L = lattice.lat_vecs
     # Convert absolute basis positions to fractional coordinates
     basis_coords = map(b -> inv(L) * b, lattice.basis_vecs)
     Crystal(L, basis_coords, types=lattice.types)
 end
 
-function Crystal(lattice::Lattice{2, 4, 3})
-    L = lattice.lat_vecs
-
-    # Expand the lattice to 3D, with a very long c axis
-    L3 = @MMatrix zeros(3, 3)
-    L3[1:2, 1:2] = L
-    # Make the vertical axis 10x longer than the longest 2D lattice vector
-    max_len = maximum(norm.(eachcol(lattice.lat_vecs)))
-    L3[3, 3] = 10. * max_len
-    L3 = SMatrix(L3)
-
-    basis_coords = map(b -> SVector{3}((inv(L) * b)..., 0.), lattice.basis_vecs)
-
-    Crystal(L3, basis_coords, types=lattice.types)
-end
-
-function Lattice(cryst::Crystal, latsize) :: Lattice{3, 9, 4}
-    Lattice{3}(cryst.lat_vecs, cryst.positions, cryst.types, latsize)
+function Lattice(cryst::Crystal, latsize) :: Lattice
+    Lattice(cryst.lat_vecs, cryst.positions, cryst.types, latsize)
 end
 
 # Number of sublattices.
@@ -126,10 +86,10 @@ cell_volume(lat::Lattice) = abs(det(lat.lat_vecs))
 # Volume of the full simulation box.
 volume(lat::Lattice) = cell_volume(lat) * prod(lat.size)
 lattice_vectors(lat::Lattice) = lat.lat_vecs
-lattice_params(lat::Lattice{3}) = lattice_params(lat.lat_vecs)
+lattice_params(lat::Lattice) = lattice_params(lat.lat_vecs)
 
 "Produce an iterator over all unit cell indices."
-@inline function eachcellindex(lat::Lattice{D}) :: CartesianIndices where {D}
+@inline function eachcellindex(lat::Lattice) :: CartesianIndices{3}
     return CartesianIndices(Tuple(lat.size))
 end
 
@@ -139,16 +99,16 @@ end
 
 #=== Indexing returns absolute coordinates of lattice points ===#
 
-@inline function Base.getindex(lat::Lattice{D}, b::Int64, brav::CartesianIndex{D}) where {D}
-    return lat.lat_vecs * convert(SVector{D, Float64}, brav) + lat.basis_vecs[b]
+@inline function Base.getindex(lat::Lattice, b::Int64, brav::CartesianIndex{3})
+    return lat.lat_vecs * convert(SVector{3, Float64}, brav) + lat.basis_vecs[b]
 end
 
-@inline function Base.getindex(lat::Lattice{D}, b::Int64, brav::NTuple{D, Int64}) where {D}
-    return lat.lat_vecs * convert(SVector{D, Float64}, brav) + lat.basis_vecs[b]
+@inline function Base.getindex(lat::Lattice, b::Int64, brav::NTuple{3, Int64})
+    return lat.lat_vecs * convert(SVector{3, Float64}, brav) + lat.basis_vecs[b]
 end
 
-@inline function Base.getindex(lat::Lattice{D}, b::Int64, brav::Vararg{Int64, D}) where {D}
-    return lat.lat_vecs * convert(SVector{D, Float64}, brav) + lat.basis_vecs[b]
+@inline function Base.getindex(lat::Lattice, b::Int64, brav::Vararg{Int64, 3})
+    return lat.lat_vecs * convert(SVector{3, Float64}, brav) + lat.basis_vecs[b]
 end
 
 # TODO: Should just be another Lattice
@@ -158,12 +118,12 @@ end
 #       These differ just by a scale factor, which is currently explicitly handled
 #        in Ewald summation calculations.
 "Defines a reciprocal lattice structure"
-struct ReciprocalLattice{D, L}
-    lat_vecs  :: SMatrix{D, D, Float64, L}     # Columns of this are the reciprocal lattice vectors
-    size      :: SVector{D, Int}
+struct ReciprocalLattice
+    lat_vecs  :: SMatrix{3, 3, Float64, 9}     # Columns of this are the reciprocal lattice vectors
+    size      :: SVector{3, Int}
 end
 
-function ReciprocalLattice(lat::Lattice{D}) where {D}
+function ReciprocalLattice(lat::Lattice)
     recip_vecs = 2π * transpose(inv(lat.lat_vecs))
 end
 
@@ -178,41 +138,17 @@ function gen_reciprocal(lat::Lattice) :: ReciprocalLattice
 end
 
 "Returns just the underlying Bravais lattice"
-function brav_lattice(lat::Lattice{D}) :: Lattice{D} where {D}
-    return Lattice{D}(
+function brav_lattice(lat::Lattice) :: Lattice
+    return Lattice(
         lat.lat_vecs,
-        [@SVector zeros(D)],
+        [@SVector zeros(3)],
         ["A"],
         lat.size
     )
 end
 
-cell_type(lattice::Lattice{3}) = cell_type(lattice.lat_vecs)
+cell_type(lattice::Lattice) = cell_type(lattice.lat_vecs)
 
-function distance(lat::Lattice{D}, b::Bond{D}) where {D}
+function distance(lat::Lattice, b::Bond)
     return norm(lat.lat_vecs * b.n + (lat.basis_vecs[b.j] - lat.basis_vecs[b.i]))
-end
-
-""" Some functions which construct common lattices
-"""
-function square_lattice(a::Float64, latsize) :: Lattice{2, 4, 3}
-    lat_vecs = SA[ a  0.0;
-                  0.0  a ]
-    basis_vecs = [SA[0.0, 0.0]]
-    basis_labels = ["A"]
-    latsize = SVector{D, Int}(latsize)
-    Lattice{2}(lat_vecs, basis_vecs, basis_labels, latsize)
-end
-
-function kagome_lattice(a::Float64, latsize) :: Lattice{2, 4, 3}
-    lat_vecs = SA[  a    0.5a;
-                   0.0  √3a/2]
-    basis_vecs = [
-        SA[0.0, 0.0],
-        SA[1/2, 0.0],
-        SA[0.0, 1/2]
-    ]
-    basis_labels = ["A", "A", "A"]
-    latsize = SVector{2, Int}(latsize)
-    Lattice{2}(lat_vecs, basis_vecs, basis_labels, latsize)
 end

--- a/src/Metropolis.jl
+++ b/src/Metropolis.jl
@@ -73,15 +73,15 @@ Each single-spin update attempts to move the spin to a random position on
  the unit sphere. One call to `sample!` will attempt to flip each spin
  `nsweeps` times.
 """
-mutable struct MetropolisSampler{D, L, Db} <: AbstractSampler
-    system     :: SpinSystem{D, L, Db}
+mutable struct MetropolisSampler <: AbstractSampler
+    system     :: SpinSystem
     β          :: Float64
     nsweeps    :: Int
     E          :: Float64
     M          :: Vec3
-    function MetropolisSampler(sys::SpinSystem{D,L,Db}, kT::Float64, nsweeps::Int) where {D,L,Db}
+    function MetropolisSampler(sys::SpinSystem, kT::Float64, nsweeps::Int)
         @assert kT != 0. "Temperature must be nonzero!"
-        new{D, L, Db}(sys, 1.0 / kT, nsweeps, energy(sys), sum(sys))
+        new(sys, 1.0 / kT, nsweeps, energy(sys), sum(sys))
     end
 end
 
@@ -98,15 +98,15 @@ to flip each spin `nsweeps` times.
 Before construting, be sure that your `SpinSystem` is initialized so that each
 spin points along its "Ising-like" axis.
 """
-mutable struct IsingSampler{D, L, Db} <: AbstractSampler
-    system     :: SpinSystem{D, L, Db}
+mutable struct IsingSampler <: AbstractSampler
+    system     :: SpinSystem
     β          :: Float64
     nsweeps    :: Int
     E          :: Float64
     M          :: Vec3
-    function IsingSampler(sys::SpinSystem{D,L,Db}, kT::Float64, nsweeps::Int) where {D,L,Db}
+    function IsingSampler(sys::SpinSystem, kT::Float64, nsweeps::Int)
         @assert kT != 0. "Temperature must be nonzero!"
-        new{D, L, Db}(sys, 1.0 / kT, nsweeps, energy(sys), sum(sys))
+        new(sys, 1.0 / kT, nsweeps, energy(sys), sum(sys))
     end
 end
 
@@ -198,7 +198,7 @@ end
 Computes the change in energy if we replace the spin at `sys[idx]`
   with `newspin`.
 """
-function local_energy_change(sys::SpinSystem{D}, idx, newspin::Vec3) where {D}
+function local_energy_change(sys::SpinSystem, idx, newspin::Vec3)
     ℋ = sys.hamiltonian
     ΔE = 0.0
     oldspin = sys[idx]

--- a/src/ParallelTempering.jl
+++ b/src/ParallelTempering.jl
@@ -50,7 +50,7 @@ end
 Constructor which initializes MPI communicator and sets sampler. -> Use on
 single communicator with no groups for now
 """
-function Replica(sampler::S) where {S<:AbstractSampler}
+function Replica(sampler::S) where {S <: AbstractSampler}
     # initialize MPI communicator and variables
     MPI.Init()
     MPI_COMM_WORLD = MPI.COMM_WORLD
@@ -210,7 +210,7 @@ end
 """
 Print xyz formatted (Lx, Ly, Lz, Sx, Sy, Sz) configurations to file 
 """
-function xyz_to_file(sys::SpinSystem{3}, output::IOStream)
+function xyz_to_file(sys::SpinSystem, output::IOStream)
     sites = reinterpret(reshape, Float64, sys.lattice)
     spins = reinterpret(reshape, Float64, sys.sites)
     xyz = vcat(sites, spins)
@@ -335,7 +335,7 @@ flow in PT simulations.
 """
 function run_FBOPT!(
     replica::Replica, 
-    kT_sched::Function; 
+    kT_sched::Function;
     max_mcs_opt::Int64=1_000_000, 
     update_interval::Int64=200_000, 
     therm_mcs::Int64=1000, 

--- a/src/Plotting.jl
+++ b/src/Plotting.jl
@@ -1,25 +1,7 @@
 """Plotting functions for lattices and spins on lattices.
 """
 
-function plot_lattice!(ax, lattice::Lattice{2}; colors=:Set1_9, markersize=20, linecolor=:grey, linewidth=1.0, kwargs...)
-    # Plot the unit cell mesh
-    plot_cells!(ax, lattice; color=linecolor, linewidth=linewidth)
-
-    unique_types = unique(lattice.types)
-    num_unique = length(unique_types)
-    colors = GLMakie.to_colormap(colors, num_unique)
-
-    # Plot markers at each site
-    sites = reinterpret(reshape, Float64, collect(lattice))
-    for (i, type) in enumerate(unique_species)
-        basis_idxs = findall(isequal(type), lattice.types)
-        xs = vec(sites[1, basis_idxs, 1:end, 1:end])
-        ys = vec(sites[2, basis_idxs, 1:end, 1:end])
-        GLMakie.scatter!(ax, xs, ys; label=type, color=color, markersize=markersize, show_axis=false, kwargs...)
-    end
-end
-
-function plot_lattice!(ax, lattice::Lattice{3}; colors=:Set1_9, markersize=200, linecolor=:grey, linewidth=1.0, kwargs...)
+function plot_lattice!(ax, lattice::Lattice; colors=:Set1_9, markersize=200, linecolor=:grey, linewidth=1.0, kwargs...)
     unique_types = unique(lattice.types)
     colors = GLMakie.to_colormap(colors, 9)
 
@@ -38,32 +20,14 @@ function plot_lattice!(ax, lattice::Lattice{3}; colors=:Set1_9, markersize=200, 
     plot_cells!(ax, lattice; color=linecolor, linewidth=linewidth)
 end
 
-function _setup_2d()
-    f = GLMakie.Figure()
-    ax = GLMakie.Axis(f[1, 1])
-    ax.autolimitaspect = 1
-    GLMakie.hidespines!(ax)
-    GLMakie.hidedecorations!(ax)
-    return f, ax
-end
-
-function _setup_3d()
+function _setup_scene()
     f = GLMakie.Figure()
     lscene = GLMakie.LScene(f[1, 1], scenekw=(camera=GLMakie.cam3d!, raw=false))
     return f, lscene
 end
 
-function plot_lattice(lattice::Lattice{2}; kwargs...)
-    f, ax = _setup_2d()
-    plot_lattice!(ax, lattice; kwargs...)
-    f[1, 2] = GLMakie.Legend(f, ax, "Species")
-    f
-end
-
-# 3D is a bit wonky at the moment - Axis3 doesn't seem to work with scatter!,
-#   so you need to use LScene
-function plot_lattice(lattice::Lattice{3}; kwargs...)
-    f, lscene = _setup_3d()
+function plot_lattice(lattice::Lattice; kwargs...)
+    f, lscene = _setup_scene()
     plot_lattice!(lscene, lattice; kwargs...)
     # TODO: Markers are often way too big.
     f[1, 2] = GLMakie.Legend(f, lscene, "Species")
@@ -87,56 +51,16 @@ Additional keyword arguments are given to `GLMakie.scatter!` which
 draws the points.
 """
 function plot_lattice(cryst::Crystal, latsize=(3,3,3); kwargs...)
-    f, ax = _setup_3d()
+    f, ax = _setup_scene()
     lattice = Lattice(cryst, latsize)
     plot_lattice!(ax, lattice; kwargs...)
     f[1, 2] = GLMakie.Legend(f, ax, "Species")
     f
 end
 
-function plot_bonds(lattice::Lattice{2}, ints::Vector{<:PairInt{2}}; bondwidth=4, kwargs...)
-    f, ax = _setup_2d()
-
-    colors = GLMakie.to_colormap(:Dark2_8, 8)
-    # Sort interactions so that longer bonds are plotted first
-    sort!(ints, by=int->distance(lattice, int.bonds[1]))
-
-    toggles = Vector{GLMakie.Toggle}()
-    labels = Vector{GLMakie.Label}()
-
-    # Plot the lattice
-    plot_lattice!(ax, lattice; kwargs...)
-    # Plot the bonds, all relative to a central atom on the first sublattice
-    basis_idx = 1
-    cent_cell = CartesianIndex(div.(lattice.size .+ 1, 2)...)
-    cent_pt = lattice[basis_idx, cent_cell]
-    for (n, int) in enumerate(ints)
-        xs = Vector{Float64}()
-        ys = Vector{Float64}()
-        for bond in int.bonds[basis_idx]
-            new_cell = offset(cent_cell, bond.n, lattice.size)
-            bond_pt = lattice[bond.j, new_cell]
-            push!(xs, cent_pt[1])
-            push!(ys, cent_pt[2])
-            push!(xs, bond_pt[1])
-            push!(ys, bond_pt[2])
-        end
-        color = colors[mod1(n, 8)]
-        seg = GLMakie.linesegments!(xs, ys; linewidth=bondwidth, label=int.label, color=color)
-
-        tog = GLMakie.Toggle(f, active=true)
-        GLMakie.connect!(seg.visible, tog.active)
-        push!(toggles, tog)
-        push!(labels, GLMakie.Label(f, int.label))
-    end
-    GLMakie.axislegend()
-    f[1, 2] = GLMakie.grid!(hcat(toggles, labels), tellheight=false)
-    f
-end
-
-function plot_bonds(lattice::Lattice{3}, ints::Vector{<:PairInt{3}};
+function plot_bonds(lattice::Lattice, ints::Vector{<:PairInt};
                     colors=:Dark2_8, bondwidth=4, kwargs...)
-    f, ax = _setup_3d()
+    f, ax = _setup_scene()
 
     # Plot the bonds, all relative to a central atom on the first sublattice
     # TODO: Make selectable in GUI
@@ -201,7 +125,7 @@ function plot_bonds(cryst::Crystal, ints::Vector{<:Interaction}, latsize=(3,3,3)
     lattice = Lattice(cryst, latsize)
     all_sites_info = propagate_site_info(cryst, sites_info)
     ℋ = HamiltonianCPU(ints, cryst, latsize, all_sites_info)
-    pair_ints = Vector{PairInt{3}}(vcat(ℋ.heisenbergs, ℋ.diag_coups, ℋ.gen_coups))
+    pair_ints = vcat(ℋ.heisenbergs, ℋ.diag_coups, ℋ.gen_coups)
     plot_bonds(lattice, pair_ints; kwargs...)
 end
 
@@ -213,7 +137,7 @@ Plot all pair interactions appearing in `sys.hamiltonian`, on the
 underlying crystal lattice. `kwargs` are passed to `plot_lattice!`.
 """
 @inline function plot_bonds(sys::SpinSystem; kwargs...)
-    pair_ints = Vector{PairInt{3}}(vcat(ℋ.heisenbergs, ℋ.diag_coups, ℋ.gen_coups))
+    pair_ints = vcat(ℋ.heisenbergs, ℋ.diag_coups, ℋ.gen_coups)
     plot_bonds(sys.lattice, pair_ints; kwargs...)
 end
 
@@ -255,7 +179,7 @@ end
 "Plot all bonds between equivalent sites i and j"
 function plot_all_bonds_between(crystal, i, j, max_dist, latsize=(3,3,3), kwargs...)
     ref_bonds = reference_bonds(crystal, max_dist)
-    interactions = Vector{HeisenbergCPU{3}}()
+    interactions = Vector{HeisenbergCPU}()
 
     prev_dist = 0.0
     dist = 0
@@ -272,7 +196,7 @@ function plot_all_bonds_between(crystal, i, j, max_dist, latsize=(3,3,3), kwargs
                 class = 1
             end
             label = "J$(dist)_$(class)"
-            push!(interactions, HeisenbergCPU{3}(1.0, crystal, bond, label))
+            push!(interactions, HeisenbergCPU(1.0, crystal, bond, label))
         end
     end
 
@@ -283,33 +207,8 @@ function plot_all_bonds_between(crystal, i, j, max_dist, latsize=(3,3,3), kwargs
     plot_bonds(crystal, interactions, latsize; kwargs...)
 end
 
-# TODO: Base.Cartesian could combine these functions
 "Plot the outlines of the unit cells of a lattice"
-function plot_cells!(ax, lattice::Lattice{2}; color=:grey, linewidth=1.0, kwargs...)
-    lattice = brav_lattice(lattice)
-
-    xs, ys = Vector{Float64}(), Vector{Float64}()
-    nx, ny = lattice.size
-    for j in 1:ny
-        left_pt, right_pt = lattice[1, 1, j], lattice[1, nx, j]
-        push!(xs, left_pt[1])
-        push!(xs, right_pt[1])
-        push!(ys, left_pt[2])
-        push!(ys, right_pt[2])
-    end
-    for i in 1:nx
-        bot_pt, top_pt = lattice[1, i, 1], lattice[1, i, ny]
-        push!(xs, bot_pt[1])
-        push!(xs, top_pt[1])
-        push!(ys, bot_pt[2])
-        push!(ys, top_pt[2])
-    end
-
-    GLMakie.linesegments!(ax, xs, ys; color=color, linewidth=linewidth)
-end
-
-"Plot the outlines of the unit cells of a lattice"
-function plot_cells!(ax, lattice::Lattice{3}; color=:grey, linewidth=1.0, kwargs...)
+function plot_cells!(ax, lattice::Lattice; color=:grey, linewidth=1.0, kwargs...)
     lattice = brav_lattice(lattice)
 
     xs, ys, zs = Vector{Float64}(), Vector{Float64}(), Vector{Float64}()
@@ -349,54 +248,7 @@ function plot_cells!(ax, lattice::Lattice{3}; color=:grey, linewidth=1.0, kwargs
     GLMakie.linesegments!(ax, xs, ys, zs; color=color, linewidth=linewidth)
 end
 
-function plot_spins(sys::SpinSystem{2}; linecolor=:grey, arrowcolor=:red, linewidth=0.1, arrowsize=0.3, kwargs...)
-    sites = reinterpret(reshape, Float64, collect(sys.lattice))
-    spins = 0.1 .* reinterpret(reshape, Float64, collect(sys.sites))
-
-    xs = vec(sites[1, 1:end, 1:end, 1:end])
-    ys = vec(sites[2, 1:end, 1:end, 1:end])
-    zs = zero(xs)
-    us = vec(spins[1, 1:end, 1:end, 1:end])
-    vs = vec(spins[2, 1:end, 1:end, 1:end])
-    ws = vec(spins[3, 1:end, 1:end, 1:end])
-
-    GLMakie.arrows(
-        xs, ys, zs, us, vs, ws;
-        linecolor=linecolor, arrowcolor=arrowcolor, linewidth=linewidth, arrowsize=arrowsize,
-        show_axis=false, kwargs...    
-    )
-end
-
-"""
-    plot_spins(sys::SpinSystem; linecolor=:grey, arrowcolor=:red, linewidth=0.1,
-                                arrowsize=0.3, arrowlength=1.0, kwargs...)
-
-Plot the spin configuration defined by `sys`. `kwargs` are passed to `GLMakie.arrows`.        
-"""
-function plot_spins(sys::SpinSystem{3}; linecolor=:grey, arrowcolor=:red,
-                    linewidth=0.1, arrowsize=0.3, arrowlength=1.0, kwargs...)
-    f, ax = _setup_3d()
-    # cam = GLMakie.cameracontrols(ax.scene)
-    # cam.projectiontype[] = GLMakie.Orthographic
-
-    sites = reinterpret(reshape, Float64, collect(sys.lattice))
-    spins = 0.2 .* reinterpret(reshape, Float64, collect(sys.sites))
-
-    xs = vec(sites[1, 1:end, 1:end, 1:end, 1:end])
-    ys = vec(sites[2, 1:end, 1:end, 1:end, 1:end])
-    zs = vec(sites[3, 1:end, 1:end, 1:end, 1:end])
-    us = arrowlength * vec(spins[1, 1:end, 1:end, 1:end, 1:end])
-    vs = arrowlength * vec(spins[2, 1:end, 1:end, 1:end, 1:end])
-    ws = arrowlength * vec(spins[3, 1:end, 1:end, 1:end, 1:end])
-
-    GLMakie.arrows(
-        xs, ys, zs, us, vs, ws;
-        linecolor=linecolor, arrowcolor=arrowcolor, linewidth=linewidth, arrowsize=arrowsize,
-        show_axis=false, kwargs...    
-    )
-end
-
-function plot_spins(lat::Lattice{3}, spins; linecolor=:grey, arrowcolor=:red,
+function plot_spins(lat::Lattice, spins; linecolor=:grey, arrowcolor=:red,
                     linewidth=0.1, arrowsize=0.3, arrowlength=1.0, kwargs...)
     sites = reinterpret(reshape, Float64, collect(lat))
     spins = reinterpret(reshape, Float64, spins.val)
@@ -415,6 +267,14 @@ function plot_spins(lat::Lattice{3}, spins; linecolor=:grey, arrowcolor=:red,
     )
 end
 
+"""
+    plot_spins(sys::SpinSystem; linecolor=:grey, arrowcolor=:red, linewidth=0.1,
+                                arrowsize=0.3, arrowlength=1.0, kwargs...)
+
+Plot the spin configuration defined by `sys`. `kwargs` are passed to `GLMakie.arrows`.        
+"""
+plot_spins(sys::SpinSystem; kwargs...) = plot_spins(sys.lattice, sys.sites; kwargs...)
+
 # No support for higher than 3D visualization, sorry!
 
 """
@@ -431,41 +291,7 @@ Produce an animation of constant-energy Landau-Lifshitz dynamics of the given `s
 Other keyword arguments are passed to `GLMakie.arrows`.
 """
 function anim_integration(
-    sys::SpinSystem{2}, fname, steps_per_frame, Δt, nframes;
-    linecolor=:grey, arrowcolor=:red, linewidth=0.1, arrowsize=0.2, kwargs...
-)
-    sites = reinterpret(reshape, Float64, collect(sys.lattice))
-    spins = 0.2 .* reinterpret(reshape, Float64, sys.sites)
-    
-    xs = vec(sites[1, 1:end, 1:end, 1:end])
-    ys = vec(sites[2, 1:end, 1:end, 1:end])
-    zs = zero(ys)
-    us = GLMakie.Node(vec(spins[1, 1:end, 1:end, 1:end]))
-    vs = GLMakie.Node(vec(spins[2, 1:end, 1:end, 1:end]))
-    ws = GLMakie.Node(vec(spins[3, 1:end, 1:end, 1:end]))
-    fig, ax, plot = GLMakie.arrows(
-        xs, ys, zs, us, vs, ws;
-        linecolor=linecolor, arrowcolor=arrowcolor, linewidth=linewidth, arrowsize=arrowsize,
-        show_axis=false, kwargs...    
-    )
-    display(fig)
-
-    framerate = 30
-    integrator = HeunP(sys)
-
-    GLMakie.record(fig, fname, 1:nframes; framerate=framerate) do frame
-        for step in 1:steps_per_frame
-            evolve!(integrator, Δt)
-        end
-        spins = 0.2 .* reinterpret(reshape, Float64, sys.sites)
-        us[] = vec(spins[1, 1:end, 1:end, 1:end])
-        vs[] = vec(spins[2, 1:end, 1:end, 1:end])
-        ws[] = vec(spins[3, 1:end, 1:end, 1:end])
-    end
-end
-
-function anim_integration(
-    sys::SpinSystem{3}, fname, steps_per_frame, Δt, nframes;
+    sys::SpinSystem, fname, steps_per_frame, Δt, nframes;
     linecolor=:grey, arrowcolor=:red, linewidth=0.1, arrowsize=0.2, kwargs...
 )
     sites = reinterpret(reshape, Float64, collect(sys.lattice))
@@ -505,42 +331,7 @@ Performs endless live constant-energy Landau-Lifshitz integration
 in an interactive window.
 """
 function live_integration(
-    sys::SpinSystem{2}, steps_per_frame, Δt;
-    linecolor=:grey, arrowcolor=:red, linewidth=0.1, arrowsize=0.2, kwargs...
-)
-    sites = reinterpret(reshape, Float64, collect(sys.lattice))
-    spins = 0.2 .* reinterpret(reshape, Float64, sys.sites)
-    
-    xs = vec(sites[1, 1:end, 1:end, 1:end])
-    ys = vec(sites[2, 1:end, 1:end, 1:end])
-    zs = zero(ys)
-    us = GLMakie.Node(vec(spins[1, 1:end, 1:end, 1:end]))
-    vs = GLMakie.Node(vec(spins[2, 1:end, 1:end, 1:end]))
-    ws = GLMakie.Node(vec(spins[3, 1:end, 1:end, 1:end]))
-    fig, ax, plot = GLMakie.arrows(
-        xs, ys, zs, us, vs, ws;
-        linecolor=linecolor, arrowcolor=arrowcolor, linewidth=linewidth, arrowsize=arrowsize,
-        show_axis=false, kwargs...    
-    )
-    display(fig)
-
-    framerate = 30
-    integrator = HeunP(sys)
-
-    while true
-        for step in 1:steps_per_frame
-            evolve!(integrator, Δt)
-        end
-        spins = 0.2 .* reinterpret(reshape, Float64, sys.sites)
-        us[] = vec(spins[1, 1:end, 1:end, 1:end])
-        vs[] = vec(spins[2, 1:end, 1:end, 1:end])
-        ws[] = vec(spins[3, 1:end, 1:end, 1:end])
-        sleep(1/framerate)
-    end
-end
-
-function live_integration(
-    sys::SpinSystem{3}, steps_per_frame, Δt;
+    sys::SpinSystem, steps_per_frame, Δt;
     linecolor=:grey, arrowcolor=:red, linewidth=0.1, arrowsize=0.2,
     arrowlength=1.0, kwargs...
 )
@@ -582,7 +373,7 @@ Performs endless live Langevin Landau-Lifshitz integration
 in an interactive window.
 """
 function live_langevin_integration(
-    sys::SpinSystem{3}, steps_per_frame, Δt, kT;
+    sys::SpinSystem, steps_per_frame, Δt, kT;
     linecolor=:grey, arrowcolor=:red, linewidth=0.1, arrowsize=0.2,
     arrowlength=1.0, α=0.1, kwargs...
 )
@@ -619,10 +410,9 @@ end
 
 "Plots slices of a 3D structure factor. Input array should have shape [3, Lx, Ly, Lz, T]"
 function plot_3d_structure_factor(sfactor::Array{Float64, 5}, iz)
-    fig, ax = _setup_3d()
+    fig, ax = _setup_scene()
 
     Sdim, Lx, Ly, Lz, T = size(sfactor)
-    @assert Sdim == 3
     # Average over Sxx, Syy, Szz - in future give controls to user
     sfactor = dropdims(sum(sfactor, dims=1) ./ 3, dims=1)
     # Index out the asked-for slice - in future give controls to user

--- a/src/Symmetry/AllowedCouplings.jl
+++ b/src/Symmetry/AllowedCouplings.jl
@@ -131,7 +131,7 @@ function is_coupling_valid(cryst::Crystal, b::BondRaw, J::Mat3)
     return true
 end
 
-function is_coupling_valid(cryst::Crystal, b::Bond{3}, J::Mat3)
+function is_coupling_valid(cryst::Crystal, b::Bond, J::Mat3)
     return is_coupling_valid(cryst, BondRaw(cryst, b), J)
 end
 
@@ -270,7 +270,7 @@ function basis_for_symmetry_allowed_couplings(cryst::Crystal, b::BondRaw)
     end
 end
 
-function basis_for_symmetry_allowed_couplings(cryst::Crystal, b::Bond{3})
+function basis_for_symmetry_allowed_couplings(cryst::Crystal, b::Bond)
     return basis_for_symmetry_allowed_couplings(cryst, BondRaw(cryst, b))
 end
 
@@ -281,11 +281,11 @@ Given a reference bond `b` and coupling matrix `J` on that bond, return a list
 of symmetry-equivalent bonds (constrained to start from atom `i`), and a
 corresponding list of symmetry-transformed coupling matrices.
 """
-function all_symmetry_related_couplings_for_atom(cryst::Crystal, i::Int, b_ref::Bond{3}, J_ref)
+function all_symmetry_related_couplings_for_atom(cryst::Crystal, i::Int, b_ref::Bond, J_ref)
     J_ref = Mat3(J_ref)
     @assert is_coupling_valid(cryst, b_ref, J_ref)
 
-    bs = Bond{3}[]
+    bs = Bond[]
     Js = Mat3[]
 
     for b in all_symmetry_related_bonds_for_atom(cryst, i, b_ref)
@@ -305,10 +305,10 @@ Given a reference bond `b` and coupling matrix `J` on that bond, return a list
 of symmetry-equivalent bonds and a corresponding list of symmetry-transformed
 coupling matrices.
 """
-function all_symmetry_related_couplings(cryst::Crystal, b_ref::Bond{3}, J_ref)
+function all_symmetry_related_couplings(cryst::Crystal, b_ref::Bond, J_ref)
     J_ref = Mat3(J_ref)
 
-    bs = Bond{3}[]
+    bs = Bond[]
     Js = Mat3[]
 
     for i in eachindex(cryst.positions)

--- a/src/Symmetry/Bond.jl
+++ b/src/Symmetry/Bond.jl
@@ -4,16 +4,10 @@
 Represents a bond between atom indices `i` and `j`, with integer displacement of
 `n[1] ... n[D]` unit cells along each dimension.
 """
-struct Bond{D}
+struct Bond
     i :: Int
     j :: Int
-    n :: SVector{D, Int}
-end
-
-function Bond(i, j, n)
-    D = length(n)
-    n = convert(SVector{D, Int}, n)
-    Bond{D}(i, j, n)
+    n :: SVector{3, Int}
 end
 
 "Represents a bond expressed as two fractional coordinates"
@@ -28,14 +22,14 @@ function Bond(cryst::Crystal, b::BondRaw)
     ri = cryst.positions[i]
     rj = cryst.positions[j]
     n = round.(Int, (b.rj-b.ri) - (rj-ri))
-    return Bond{3}(i, j, n)
+    return Bond(i, j, n)
 end
 
-function BondRaw(cryst::Crystal, b::Bond{3})
+function BondRaw(cryst::Crystal, b::Bond)
     return BondRaw(cryst.positions[b.i], cryst.positions[b.j]+b.n)
 end
 
-function Base.show(io::IO, mime::MIME"text/plain", bond::Bond{3})
+function Base.show(io::IO, mime::MIME"text/plain", bond::Bond)
     print(io, "Bond($(bond.i), $(bond.j), $(bond.n))")
 end
 
@@ -52,7 +46,7 @@ function displacement(cryst::Crystal, b::BondRaw)
     return cryst.lat_vecs * (b.rj - b.ri)
 end
 
-function displacement(cryst::Crystal, b::Bond{3})
+function displacement(cryst::Crystal, b::Bond)
     return displacement(cryst, BondRaw(cryst, b))
 end
 
@@ -65,7 +59,7 @@ function distance(cryst::Crystal, b::BondRaw)
     return norm(displacement(cryst, b))
 end
 
-function distance(cryst::Crystal, b::Bond{3})
+function distance(cryst::Crystal, b::Bond)
     return norm(displacement(cryst, b))
 end
 
@@ -73,7 +67,7 @@ function transform(s::SymOp, b::BondRaw)
     return BondRaw(transform(s, b.ri), transform(s, b.rj))
 end
 
-function transform(cryst::Crystal, s::SymOp, b::Bond{3})
+function transform(cryst::Crystal, s::SymOp, b::Bond)
     return Bond(cryst, transform(s, BondRaw(cryst, b)))
 end
 

--- a/src/Symmetry/Crystal.jl
+++ b/src/Symmetry/Crystal.jl
@@ -6,8 +6,8 @@
 Defines a symmetry operation belonging to a 3D space group, operating on fractional coordinates.
 """
 struct SymOp
-    R::Mat3
-    T::Vec3
+    R :: Mat3
+    T :: Vec3
 end
 
 function Base.show(io::IO, ::MIME"text/plain", s::SymOp)
@@ -73,16 +73,14 @@ A type holding all geometry and symmetry information needed to represent
  a three-dimensional crystal.
 """
 struct Crystal
-    lat_vecs       :: Mat3                # Lattice vectors as columns
-
-    positions      :: Vector{Vec3}        # Positions in fractional coords
-    types          :: Vector{String}      # Types
-    classes        :: Vector{Int}         # Class indices
+    lat_vecs       :: Mat3                                 # Lattice vectors as columns
+    positions      :: Vector{Vec3}                         # Positions in fractional coords
+    types          :: Vector{String}                       # Types
+    classes        :: Vector{Int}                          # Class indices
     sitesyms       :: Union{Nothing, Vector{SiteSymmetry}} # Optional site symmetries
-
-    symops         :: Vector{SymOp}       # Symmetry operations
-    spacegroup     :: String              # Description of space group
-    symprec        :: Float64             # Tolerance to imperfections in symmetry
+    symops         :: Vector{SymOp}                        # Symmetry operations
+    spacegroup     :: String                               # Description of space group
+    symprec        :: Float64                              # Tolerance to imperfections in symmetry
 end
 
 """
@@ -98,9 +96,6 @@ nbasis(cryst::Crystal) = length(cryst.positions)
 Volume of the crystal unit cell.
 """
 cell_volume(cryst::Crystal) = abs(det(cryst.lat_vecs))
-
-# This will remain 3 for the foreseeable future.
-dimension(cryst::Crystal) = 3
 
 """
     equiv_sites(crystal::Crystal, b::Int)
@@ -522,7 +517,7 @@ end
 
 function cubic_crystal(; a=1.0)
     lat_vecs = lattice_vectors(a, a, a, 90, 90, 90)
-    basis_vecs = [0, 0, 0]
+    basis_vecs = [[0, 0, 0]]
     Crystal(lat_vecs, basis_vecs)
 end
 

--- a/src/Symmetry/Printing.jl
+++ b/src/Symmetry/Printing.jl
@@ -66,7 +66,7 @@ function _print_allowed_coupling(basis_strs; prefix)
     end
 end
 
-function print_allowed_coupling(cryst::Crystal, b::Bond{3}; prefix="", digits=2, tol=1e-4)
+function print_allowed_coupling(cryst::Crystal, b::Bond; prefix="", digits=2, tol=1e-4)
     basis = basis_for_symmetry_allowed_couplings(cryst, b)
     basis_strs = _coupling_basis_strings(zip('A':'Z', basis); digits, tol)
     _print_allowed_coupling(basis_strs; prefix)
@@ -78,7 +78,7 @@ end
 
 Pretty-prints symmetry information for bond `bond` or atom index `i`.
 """
-function print_bond(cryst::Crystal, b::Bond{3}; digits=2, tol=1e-4)
+function print_bond(cryst::Crystal, b::Bond; digits=2, tol=1e-4)
     ri = cryst.positions[b.i]
     rj = cryst.positions[b.j] + b.n
 
@@ -124,7 +124,7 @@ function print_bond(cryst::Crystal, b::Bond{3}; digits=2, tol=1e-4)
 end
 
 function print_bond(cryst::Crystal, i::Int; digits=2, tol=1e-4)
-    print_bond(cryst, Bond{3}(i, i, [0, 0, 0]); digits, tol)
+    print_bond(cryst, Bond(i, i, [0, 0, 0]); digits, tol)
 end
 
 

--- a/src/Systems.jl
+++ b/src/Systems.jl
@@ -1,6 +1,6 @@
 import Random # overload Random.rand!
 
-abstract type AbstractSystem{T, D, L, Db} <: AbstractArray{T, Db} end
+abstract type AbstractSystem{T} <: AbstractArray{T, 4} end
 Base.IndexStyle(::Type{<:AbstractSystem}) = IndexLinear()
 Base.size(sys::S) where {S <: AbstractSystem} = size(sys.sites)
 Base.getindex(sys::S, i::Int) where {S <: AbstractSystem} = sys.sites[i]
@@ -21,20 +21,20 @@ end
 Defines a collection of charges. Currently primarily used to test ewald
  summation calculations.
 """
-mutable struct ChargeSystem{D, L, Db} <: AbstractSystem{Float64, D, L, Db}
-    lattice       :: Lattice{D, L, Db}    # Definition of underlying lattice
-    sites         :: Array{Float64, Db}   # Holds charges at each site
+mutable struct ChargeSystem <: AbstractSystem{Float64}
+    lattice :: Lattice             # Definition of underlying lattice
+    sites   :: Array{Float64, 4}   # Holds charges at each site
 end
 
 """
 Defines a collection of spins, as well as the Hamiltonian they interact under.
  This is the main type to interface with most of the package.
 """
-mutable struct SpinSystem{D, L, Db} <: AbstractSystem{Vec3, D, L, Db}
-    lattice        :: Lattice{D, L, Db}   # Definition of underlying lattice
-    hamiltonian    :: HamiltonianCPU{D}   # Contains all interactions present
-    sites          :: Array{Vec3, Db}     # Holds actual spin variables
-    sites_info     :: Vector{SiteInfo}    # Characterization of each basis site
+mutable struct SpinSystem <: AbstractSystem{Vec3}
+    lattice     :: Lattice            # Definition of underlying lattice
+    hamiltonian :: HamiltonianCPU     # Contains all interactions present
+    sites       :: Array{Vec3, 4}     # Holds actual spin variables: Axes are [Basis, CellA, CellB, CellC]
+    sites_info  :: Vector{SiteInfo}   # Characterization of each basis site
 end
 
 """
@@ -50,7 +50,6 @@ function ChargeSystem(lat::Lattice)
 end
 
 function ChargeSystem(cryst::Crystal, latsize)
-    sites = zeros(nbasis(cryst), sites_size)
     lattice = Lattice(crystal, latsize)
     return ChargeSystem(lattice)
 end
@@ -126,7 +125,7 @@ function SpinSystem(crystal::Crystal, ints::Vector{<:Interaction}, latsize, site
     sites = fill(SA[0.0, 0.0, 1.0], sites_size)
 
     # Default unit system is (meV, K, Å, T)
-    SpinSystem{3, 9, 4}(lattice, ℋ_CPU, sites, all_sites_info)
+    SpinSystem(lattice, ℋ_CPU, sites, all_sites_info)
 end
 
 function Base.show(io::IO, ::MIME"text/plain", sys::SpinSystem)

--- a/src/WangLandau/WangLandau.jl
+++ b/src/WangLandau/WangLandau.jl
@@ -1,12 +1,12 @@
 import Random # TODO: Move `rng` field up to SpinSystem
 
 """ 
-    mutable struct WangLandau{D, L, Db, F<:Function} 
+    mutable struct WangLandau{F<:Function} 
 
 Wang-Landau sampler. All parameters have default values that can be overwritten,
 but a SpinSystem must be passed during construction. 
 """
-Base.@kwdef mutable struct WangLandau{D, L, Db, F<:Function}
+Base.@kwdef mutable struct WangLandau{F<:Function}
     # adaptive binned histogram
     hist::BinnedArray{Float64, Int64} = BinnedArray{Float64, Int64}()
 
@@ -43,7 +43,7 @@ Base.@kwdef mutable struct WangLandau{D, L, Db, F<:Function}
     )
 
     # spin system
-    system::SpinSystem{D, L, Db}
+    system::SpinSystem
 
     # minimum energy (not binned) found in simulation
     E_min::Float64 = Inf

--- a/test/test_ewald.jl
+++ b/test/test_ewald.jl
@@ -107,7 +107,7 @@ end
     opposite charges Q = ±1/(2ϵ) separated by displacements d = 2ϵp centered on the original
     lattice sites.
 """
-function _approx_dip_as_mono(sys::SpinSystem{3, 9, 4}; ϵ::Float64=0.1) :: ChargeSystem{3, 9, 4}
+function _approx_dip_as_mono(sys::SpinSystem; ϵ::Float64=0.1) :: ChargeSystem
     lattice = sys.lattice
     sites = sys.sites
 
@@ -142,7 +142,7 @@ function _approx_dip_as_mono(sys::SpinSystem{3, 9, 4}; ϵ::Float64=0.1) :: Charg
 
     new_lattice = Sunny.Lattice(new_lat_vecs, new_basis, new_latsize)
 
-    return ChargeSystem{3, 9, 4}(new_lattice, new_sites)
+    return ChargeSystem(new_lattice, new_sites)
 end
 
 """

--- a/test/test_pair_interactions.jl
+++ b/test/test_pair_interactions.jl
@@ -31,4 +31,26 @@
 
     test_type_mapping()
 
+    function Base.isapprox(int::Sunny.QuadraticInteraction, int2::Sunny.QuadraticInteraction; kwargs...)
+        exchange_eq = isapprox(int.J, int2.J; kwargs...)
+        bond_eq = int.bond == int2.bond
+        exchange_eq && bond_eq
+    end
+
+    # Test that the output of `show` on pair interactions actually creates the correct interaction again,
+    #   up to truncation error in `show`. (Does not check label on interactions, which isn't printed in `show`)
+    function test_quadratic_shown_info()
+        io = IOBuffer()
+        context = IOContext(io)
+        exchange_ints = diamond_test_exchanges()
+        for int in exchange_ints
+            show(context, "text/plain", int)
+            output = String(take!(io))
+            reparsed_int = eval(Meta.parse(output))
+            @test isapprox(int, reparsed_int; atol=1e-4)
+        end
+    end
+
+    test_quadratic_shown_info()
+
 end


### PR DESCRIPTION
This PR removes the arbitrary-dimensionality functionality of many types throughout Sunny, as some components were effectively locking the dimensionality to 3 anyway. Additionally, 1D + 2D simulations can easily still be performed in the 3D framework, and nobody wants to do >3D simulations.

Effectively, three type parameters can be removed from many types throughout Sunny, and the dimensionality of many arrays is now fixed and statically known. This should buy us some budget for complexity when we inevitably need to add more type parameters for SU(N) simulations.

We also can remove `OnSiteQuadratic`, which only existed in the first place to dodge an awkward unknown-dimensionality problem we previously had.