### PR TITLE
Refactor bond-handling code in PairInteractions.jl into new type `BondTable`

### DIFF
--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -12,7 +12,7 @@ The high-level outline of performing a simulation is:
 1. Create a [`Crystal`](@ref), either by providing explicit geometry information
     (Example 1), or by loading a `.cif` file (Example 2).
 2. Using the `Crystal`, construct a collection of [Interactions](@ref).
-3. Assemble a [`SpinSystem`](@ref) using the newly created `Crystal` and Interactions, the size of the simulation box, and optionally information on the spin magnitude and ``g``-tensors of each site by passing a list of `SiteInfo`.
+3. Assemble a [`SpinSystem`](@ref) using the newly created `Crystal` and interactions, the size of the simulation box, and optionally information on the spin magnitude and ``g``-tensors of each site by passing a list of `SiteInfo`.
 4. Construct a sampler, either a [`LangevinSampler`](@ref) (Example 1), or a 
     [`MetropolisSampler`](@ref) (Example 2).
 5. Use the sampler directly to sample new states, or use it to perform [Structure factor calculations](@ref).

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -12,7 +12,7 @@ The high-level outline of performing a simulation is:
 1. Create a [`Crystal`](@ref), either by providing explicit geometry information
     (Example 1), or by loading a `.cif` file (Example 2).
 2. Using the `Crystal`, construct a collection of [Interactions](@ref).
-3. Assemble a [`SpinSystem`](@ref) using the newly created `Crystal` and `Interaction`s, the size of the simulation box, and optionally information on the spin magnitude and ``g``-tensors of each site by passing a list of `SiteInfo`.
+3. Assemble a [`SpinSystem`](@ref) using the newly created `Crystal` and Interactions, the size of the simulation box, and optionally information on the spin magnitude and ``g``-tensors of each site by passing a list of `SiteInfo`.
 4. Construct a sampler, either a [`LangevinSampler`](@ref) (Example 1), or a 
     [`MetropolisSampler`](@ref) (Example 2).
 5. Use the sampler directly to sample new states, or use it to perform [Structure factor calculations](@ref).

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -28,22 +28,23 @@ SpinSystem(...; μB=0.67171381563034223582, μ0=17.3497470317891588)
 ```
 
 
-## Handling `Interaction`s
+## Handling Interactions
 
 Interactions exist at two levels:
 
-1. The types that the user create and interface with (living in `Interactions.jl`)
-2. The types that this gets converted behind the scenes upon creating a `SpinSystem`
-    (which are scattered throughout the codebase).
+1. The types that the user create and interface with (subtypes of `AbstractInteraction` and
+    living in `Interactions.jl`).
+2. The types that these get converted to behind the scenes upon creating a `SpinSystem`
+    (subtypes of `AbstractInteractionCPU`, and which are scattered throughout the codebase).
 
-To define a new type of `Interaction` which can appear in a Hamiltonian,
+To define a new type of interaction which can appear in a Hamiltonian,
 one must provide both of these types (which may be the same!), a way to convert from
 the first to the second, and a collection of functionalities on the second
 needed for various simulation tasks. We provide the list of required steps below, and for
 explicit examples see the core interactions defined across `src/Interactions.jl`
 and `src/PairInteractions.jl`.
 
-**(1)** Define a new struct which is a subtype of `Interaction`. This is the user-facing
+**(1)** Define a new struct which is a subtype of `AbstractInteraction`. This is the user-facing
          type, which should be the minimal specification needed to specify the
          interaction. As much as possible, instances of this type should be agnostic to
          the final crystal geometry they'll be placed on. We'll refer to this type
@@ -51,14 +52,14 @@ and `src/PairInteractions.jl`.
 
 **(2)** Create _another_ struct which will handle how to actually explicitly compute
          terms arising from your interaction on a specific lattice. We'll refer to this
-         type here as `MyIntInternal <: InteractionCPU`. This should expose a constructor
+         type here as `MyIntInternal <: AbstractInteractionCPU`. This should expose a constructor
          `MyIntInternal(int::MyInt, crystal::Crystal, latsize)`.
 
 **(3)** Provide the following methods:
 
-- `Sunny.energy(sys::SpinSystem, int::MyIntInternal)` which computes the total term in the
+- `Sunny.energy(spins::Array{Vec3, 4}, int::MyIntInternal)` which computes the total term in the
      Hamiltonian given the state of the system.
-- `Sunny._accum_field!(B::Array{Vec3}, spins::Array{Vec3}, int::MyIntInternal)` which
+- `Sunny._accum_field!(B::Array{Vec3, 4}, spins::Array{Vec3, 4}, int::MyIntInternal)` which
     accumulates the local "field" coming from this interaction into `B` given the state
     of the `spins`. Specifically, this function call should perform:
         ``𝐁ᵢ = 𝐁ᵢ - ∇_{𝐒ᵢ} ℋ_I``

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -32,7 +32,7 @@ SpinSystem(...; μB=0.67171381563034223582, μ0=17.3497470317891588)
 
 Interactions exist at two levels:
 
-1. The types that the user create and interface with (subtypes of `AbstractInteraction` and
+1. The types that the user creates and interfaces with (subtypes of `AbstractInteraction` and
     living in `Interactions.jl`).
 2. The types that these get converted to behind the scenes upon creating a `SpinSystem`
     (subtypes of `AbstractInteractionCPU`, and which are scattered throughout the codebase).

--- a/docs/src/library.md
+++ b/docs/src/library.md
@@ -57,7 +57,7 @@ dipole_dipole
 
 ```@docs
 SpinSystem
-SpinSystem(::Crystal, ::Vector{<:Sunny.Interaction}, latsize, ::Vector{SiteInfo})
+SpinSystem(::Crystal, ::Vector{<:Sunny.AbstractInteraction}, latsize, ::Vector{SiteInfo}; μB, μ0)
 rand!(::SpinSystem)
 randflips!(::SpinSystem)
 energy
@@ -114,5 +114,6 @@ integrations.
 ```@docs
 HeunP
 LangevinHeunP
+SphericalMidpoint
 evolve!
 ```

--- a/examples/PT_afm_diamond.jl
+++ b/examples/PT_afm_diamond.jl
@@ -4,7 +4,8 @@ using MPI
 # run using the command: "mpiexec -n [n_procs] julia --project [PT_afm_diamond.jl]"
 
 #######################################################
-#   system setup
+#   System setup
+#######################################################
 
 # make lattice
 crystal = Sunny.diamond_crystal()
@@ -24,6 +25,7 @@ rand!(sys)
 
 #######################################################
 #   PT setup
+#######################################################
 
 # make replica for PT
 replica = Replica(MetropolisSampler(sys, 1.0, 1))

--- a/src/Ewald.jl
+++ b/src/Ewald.jl
@@ -404,7 +404,7 @@ Dipole-dipole interactions computed in real-space. `DipoleFourier` should
 be preferred in actual simulations, but this type persists as a cross-check
 to test the Fourier-space calculations.
 """
-struct DipoleRealCPU <: InteractionCPU
+struct DipoleRealCPU <: AbstractInteractionCPU
     int_mat :: OffsetArray{Mat3, 5, Array{Mat3, 5}}
 end
 

--- a/src/FourierAccel.jl
+++ b/src/FourierAccel.jl
@@ -22,7 +22,7 @@ Dipole-dipole interactions computed in Fourier-space. Should produce
 identical results (up to numerical precision) as `DipoleReal`, but
 is asymptotically faster.
 """
-struct DipoleFourierCPU <: InteractionCPU
+struct DipoleFourierCPU <: AbstractInteractionCPU
     int_mat     :: Array{ComplexF64, 7}
     _spins_ft   :: Array{ComplexF64, 5}  # Space for Fourier-transforming spins
     _field_ft   :: Array{ComplexF64, 5}  # Space for holding Fourier-transformed fields

--- a/src/Hamiltonian.jl
+++ b/src/Hamiltonian.jl
@@ -1,7 +1,7 @@
 # Functions associated with HamiltonianCPU, which maintains the actual internal
 # interaction types and orchestrates energy/field calculations.
 
-function validate_and_clean_interactions(ints::Vector{<:Interaction}, crystal::Crystal, latsize::Vector{Int64})
+function validate_and_clean_interactions(ints::Vector{<:AbstractInteraction}, crystal::Crystal, latsize::Vector{Int64})
     # Validate all interactions
     for int in ints
         if isa(int, QuadraticInteraction)
@@ -57,7 +57,7 @@ struct HamiltonianCPU
 end
 
 """
-    HamiltonianCPU(ints::Vector{<:Interaction}, crystal, latsize, sites_info::Vector{SiteInfo})
+    HamiltonianCPU(ints, crystal, latsize, sites_info::Vector{SiteInfo})
 
 Construct a `HamiltonianCPU` from a list of interactions, converting
 each of the interactions into the proper backend type specialized
@@ -65,7 +65,7 @@ for the given `crystal` and `latsize`.
 
 Note that `sites_info` must be complete when passed to this constructor.
 """
-function HamiltonianCPU(ints::Vector{<:Interaction}, crystal::Crystal,
+function HamiltonianCPU(ints::Vector{<:AbstractInteraction}, crystal::Crystal,
                         latsize::Vector{Int64}, sites_info::Vector{SiteInfo};
                         μB=BOHR_MAGNETON::Float64, μ0=VACUUM_PERM::Float64)
     ext_field   = nothing

--- a/src/Interactions.jl
+++ b/src/Interactions.jl
@@ -1,22 +1,22 @@
 """Structs for defining various terms in a spin Hamiltonian.
 """
 
-abstract type Interaction end      # Subtype this for user-facing interfaces
-abstract type InteractionCPU end   # Subtype this for actual internal CPU implementations
-abstract type InteractionGPU end   # Subtype this for actual internal GPU implementations
+abstract type AbstractInteraction end      # Subtype this for user-facing interfaces
+abstract type AbstractInteractionCPU end   # Subtype this for actual internal CPU implementations
+abstract type AbstractInteractionGPU end   # Subtype this for actual internal GPU implementations
 
 
-struct QuadraticInteraction <: Interaction
+struct QuadraticInteraction <: AbstractInteraction
     J     :: Mat3
     bond  :: Bond
     label :: String
 end
 
-struct ExternalField <: Interaction
+struct ExternalField <: AbstractInteraction
     B :: Vec3
 end
 
-struct DipoleDipole <: Interaction
+struct DipoleDipole <: AbstractInteraction
     extent   :: Int
     η        :: Float64
 end

--- a/src/Metropolis.jl
+++ b/src/Metropolis.jl
@@ -209,7 +209,7 @@ function local_energy_change(sys::SpinSystem, idx, newspin::Vec3)
         ΔE -= ℋ.ext_field.effBs[i] ⋅ spindiff
     end
     for heisen in ℋ.heisenbergs
-        J = heisen.effJ
+        J = first(heisen.bondtable.data)
         for (bond, _) in sublat_bonds(heisen.bondtable, i)
             if bond.i == bond.j && iszero(bond.n)
                 ΔE += J * (newspin⋅newspin - oldspin⋅oldspin)

--- a/src/Metropolis.jl
+++ b/src/Metropolis.jl
@@ -210,8 +210,8 @@ function local_energy_change(sys::SpinSystem, idx, newspin::Vec3)
     end
     for heisen in ℋ.heisenbergs
         J = heisen.effJ
-        for bond in heisen.bonds[i]
-            if i == bond.j && iszero(bond.n)
+        for (bond, _) in sublat_bonds(heisen.bondtable, i)
+            if bond.i == bond.j && iszero(bond.n)
                 ΔE += J * (newspin⋅newspin - oldspin⋅oldspin)
             else
                 Sⱼ = sys[bond.j, offset(cell, bond.n, sys.lattice.size)]
@@ -220,8 +220,8 @@ function local_energy_change(sys::SpinSystem, idx, newspin::Vec3)
         end
     end
     for diag_coup in ℋ.diag_coups
-        for (J, bond) in zip(diag_coup.effJs[i], diag_coup.bonds[i])
-            if i == bond.j && iszero(bond.n)
+        for (bond, J) in sublat_bonds(diag_coup.bondtable, i)
+            if bond.i == bond.j && iszero(bond.n)
                 ΔE += newspin⋅(J.*newspin) - oldspin⋅(J.*oldspin)
             else
                 Sⱼ = sys[bond.j, offset(cell, bond.n, sys.lattice.size)]
@@ -230,8 +230,8 @@ function local_energy_change(sys::SpinSystem, idx, newspin::Vec3)
         end
     end
     for gen_coup in ℋ.gen_coups
-        for (J, bond) in zip(gen_coup.effJs[i], gen_coup.bonds[i])
-            if i == bond.j && iszero(bond.n)
+        for (bond, J) in sublat_bonds(gen_coup.bondtable, i)
+            if bond.i == bond.j && iszero(bond.n)
                 ΔE += dot(newspin, J, newspin) - dot(oldspin, J, oldspin)
             else
                 Sⱼ = sys[bond.j, offset(cell, bond.n, sys.lattice.size)]

--- a/src/PairInteractions.jl
+++ b/src/PairInteractions.jl
@@ -6,37 +6,6 @@ Upon creation of a SpinSystem, all pair interactions get converted into their
 """
 
 """
-    cull_bonds(bonds::Vector{Vector{Bond{D}}}, Js::Vector{Vector{S}}) where {D, S}
-
-Culls presorted lists of bonds to keep only those with `bond.i` <= `bond.j`.
-Bonds with `bond.i == bond.j` need to be further culled to only keep half,
-  removing one from each pair with inverted `bond.n`.
-"""
-function cull_bonds(bonds::Vector{Vector{Bond}}, Js::Vector{Vector{S}}) where {S}
-    nb = length(bonds)
-
-    culled_bonds = [Bond[] for _ in 1:nb]
-    culled_Js = [S[] for _ in 1:nb]
-    for i in 1:nb
-        for (bond, J) in zip(bonds[i], Js[i])
-            if bond.i < bond.j
-                push!(culled_bonds[i], bond)
-                push!(culled_Js[i], J)
-            end
-            if bond.i == bond.j
-                neg_bond = Bond(bond.i, bond.j, -bond.n)
-                if !(neg_bond in culled_bonds[i])
-                    push!(culled_bonds[i], bond)
-                    push!(culled_Js[i], J)
-                end
-            end
-        end
-    end
-    (culled_bonds, culled_Js)
-end
-
-
-"""
     BondTable{T}
 
 Stores all of the bonds and associated data (e.g. exchange scalars/matrices) of type T
@@ -49,21 +18,37 @@ struct BondTable{T}
     data          :: Vector{T}         # Data T associated with each bond in `bonds`
     culled_data   :: Vector{T}         # Culled data T associated with each bond in `bonds`
     basis_indices :: Vector{Int}       # Indices to first bond of each basis index in `bonds`
-    function BondTable(bonds::Vector{Vector{Bond}}, data::Vector{Vector{T}}) where {T}
-        (culled_bonds, culled_data) = cull_bonds(bonds, data)
+end
 
-        num_bonds_per_basis = map(length, bonds)
-        basis_indices = cumsum(num_bonds_per_basis) .- length(bonds[1]) .+ 1
-        push!(basis_indices, sum(num_bonds_per_basis) + 1)
+"""Construct a `BondTable` given a `Crystal`, and a `Bond` along with its associated
+    exchange matrix. Performs the symmetry transformations to obtain all other bonds
+    and exchanges matrices.
+"""
+function BondTable(crystal::Crystal, bond::Bond, J::Mat3)
+    bonds = Vector{Bond}()
+    Js = Vector{Mat3}()
+    basis_indices = [1]
 
-        # Flatten everything from Vector{Vector{...}} to Vector{...}
-        bonds = reduce(vcat, bonds)
-        culled_bonds = reduce(vcat, culled_bonds)
-        data = reduce(vcat, data)
-        culled_data = reduce(vcat, culled_data)
-
-        new{T}(bonds, culled_bonds, data, culled_data, basis_indices)
+    for i in 1:nbasis(crystal)
+        (symbonds, symJs) = all_symmetry_related_couplings_for_atom(crystal, i, bond, J)
+        append!(bonds, symbonds)
+        append!(Js, symJs)
+        push!(basis_indices, last(basis_indices) + length(symbonds))
     end
+
+    # Compute the minimal set of the bonds/Js needed to specify all bonds
+    # Bonds with i ↔ j and n ↔ -n are equivalent: only keep one of each pair
+    culled_bonds = Vector{Bond}()
+    culled_Js = Vector{Mat3}()
+    for (bond, J) in zip(bonds, Js)
+        neg_bond = Bond(bond.j, bond.i, -bond.n)
+        if !(neg_bond in culled_bonds)
+            push!(culled_bonds, bond)
+            push!(culled_Js, J)
+        end
+    end
+
+    BondTable{Mat3}(bonds, culled_bonds, Js, culled_Js, basis_indices)
 end
 
 function Base.show(io::IO, ::MIME"text/plain", bondtable::BondTable{T}) where {T}
@@ -71,6 +56,7 @@ function Base.show(io::IO, ::MIME"text/plain", bondtable::BondTable{T}) where {T
 end
 
 Base.length(bondtable::BondTable) = length(bondtable.bonds)
+nbasis(bondtable::BondTable) = length(bondtable.basis_indices) - 1
 ## These functions generate iterators producing (bond, data) for various subsets of bonds ##
 all_bonds(bondtable::BondTable) = zip(bondtable.bonds, bondtable.data)
 culled_bonds(bondtable::BondTable) = zip(bondtable.culled_bonds, bondtable.culled_data)
@@ -78,6 +64,16 @@ function sublat_bonds(bondtable::BondTable, i::Int)
     @unpack bonds, data, basis_indices = bondtable
     @boundscheck checkindex(Bool, 1:length(basis_indices)-1, i) ? nothing : throw(BoundsError(bondtable, i))
     zip(bonds[basis_indices[i]:basis_indices[i+1]-1], data[basis_indices[i]:basis_indices[i+1]-1])
+end
+
+# This method `map`'s only the data within a BondTable, not the bonds themselves.
+function Base.map(f, bondtable::BondTable)
+    @unpack bonds, culled_bonds, data, culled_data, basis_indices = bondtable
+    new_data = map(f, data)
+    new_culled_data = map(f, culled_data)
+    return BondTable{eltype(new_data)}(
+        bonds, culled_bonds, new_data, new_culled_data, basis_indices
+    )
 end
 
 abstract type AbstractPairIntCPU <: AbstractInteractionCPU end
@@ -89,7 +85,6 @@ Implements an exchange interaction which is proportional to
 the identity matrix.
 """
 struct HeisenbergCPU <: AbstractPairIntCPU
-    effJ         :: Float64               # In Heisenberg interaction, all bonds have identical J
     bondtable    :: BondTable{Float64}    # Bonds store effective J's = S_i J S_j (all identical)
     label        :: String
 end
@@ -128,54 +123,29 @@ isdiag(tol) = Base.Fix2(isdiag, tol)
 function convert_quadratic(int::QuadraticInteraction, cryst::Crystal, sites_info::Vector{SiteInfo}; tol=1e-6)
     @unpack J, bond, label = int
 
-    # Compute the bonds and exchange matrices which live on each basis site
-    # Outer vector corresponds to each basis site, inner vector is all bonds/matrices on that basis site
-    sorted_bonds = Vector{Vector{Bond}}()
-    sorted_Js = Vector{Vector{Mat3}}()
-    for i in 1:nbasis(cryst)
-        (bs, Js) = all_symmetry_related_couplings_for_atom(cryst, i, bond, J)
-        push!(sorted_bonds, bs)
-        push!(sorted_Js, Js)
-    end
-
     # Product S_i S_j between sites connected by the bond -- same for all bonds in a class
     # To get interactions quadratic in the unit vectors stored by `SpinSystem`, we internally
     #  store effective exchange matrices (Si J Sj).
     SiSj = sites_info[bond.i].S * sites_info[bond.j].S
-    sorted_Js .*= SiSj
+    J *= SiSj
+    bondtable = BondTable(cryst, bond, J)
 
-    if all(isheisen(tol), Base.Iterators.flatten(sorted_Js))
+    if all(isheisen(tol), bondtable.culled_data)
         # Pull out the Heisenberg scalar from each exchange matrix
-        scalar_sorted_Js = [
-            [J[1,1] for J in Js]
-            for Js in sorted_Js
-        ]
-        # In the Heisenberg case, all J values are identical -- grab that scalar from the
-        #  first non-empty list.
-        effJ = first(first(
-            Iterators.filter(
-                list_Js->length(list_Js) > 0,
-                scalar_sorted_Js
-            )
-        ))
-        bondtable = BondTable(sorted_bonds, scalar_sorted_Js)
-        return HeisenbergCPU(effJ, bondtable, label)
-    elseif all(isdiag(tol), Base.Iterators.flatten(sorted_Js))
+        bondtable = map(J->J[1,1], bondtable)
+        return HeisenbergCPU(bondtable, label)
+    elseif all(isdiag(tol), bondtable.culled_data)
         # Pull out the diagonal of each exchange matrix
-        vec_sorted_Js = [
-            [diag(M) for M in Js]
-            for Js in sorted_Js
-        ]
-        bondtable = BondTable(sorted_bonds, vec_sorted_Js)
+        bondtable = map(J->diag(J), bondtable)
         return DiagonalCouplingCPU(bondtable, label)
     else
-        bondtable = BondTable(sorted_bonds, sorted_Js)
         return GeneralCouplingCPU(bondtable, label)
     end
 end
 
 function energy(spins::Array{Vec3}, heisenberg::HeisenbergCPU)
-    @unpack effJ, bondtable = heisenberg
+    bondtable = heisenberg.bondtable
+    effJ = first(bondtable.data)
     E = 0.0
 
     latsize = size(spins)[2:end]
@@ -224,7 +194,8 @@ end
 
 "Accumulates the local -∇ℋ coming from Heisenberg couplings into `B`"
 @inline function _accum_neggrad!(B::Array{Vec3}, spins::Array{Vec3}, heisen::HeisenbergCPU)
-    @unpack effJ, bondtable = heisen
+    bondtable = heisen.bondtable
+    effJ = first(bondtable.data)
 
     latsize = size(spins)[2:end]
     for (bond, _) in culled_bonds(bondtable)

--- a/src/PairInteractions.jl
+++ b/src/PairInteractions.jl
@@ -5,21 +5,12 @@ Upon creation of a SpinSystem, all pair interactions get converted into their
  corresponding type here.
 """
 
-"Presorts a flat list of bonds into a nested list, with the outer list corresponding to `bond.i`"
-function presort_bonds(bonds::Vector{Bond}) :: Vector{Vector{Bond}}
-    nb = maximum(b->b.i, bonds)
+"""
+    cull_bonds(bonds::Vector{Vector{Bond{D}}}, Js::Vector{Vector{S}}) where {D, S}
 
-    sorted_bonds = [Bond[] for _ in 1:nb]
-    for bond in bonds
-        push!(sorted_bonds[bond.i], bond)
-    end
-
-    sorted_bonds
-end
-
-"""Culls presorted lists of bonds to keep only those with `bond.i` <= `bond.j`.
-   Bonds with `bond.i == bond.j` need to be further culled to only keep half,
-    removing one from each pair with inverted `bond.n`.
+Culls presorted lists of bonds to keep only those with `bond.i` <= `bond.j`.
+Bonds with `bond.i == bond.j` need to be further culled to only keep half,
+  removing one from each pair with inverted `bond.n`.
 """
 function cull_bonds(bonds::Vector{Vector{Bond}}, Js::Vector{Vector{S}}) where {S}
     nb = length(bonds)
@@ -44,48 +35,86 @@ function cull_bonds(bonds::Vector{Vector{Bond}}, Js::Vector{Vector{S}}) where {S
     (culled_bonds, culled_Js)
 end
 
+
 """
-    HeisenbergCPU
+    BondTable{T}
+
+Stores all of the bonds and associated data (e.g. exchange scalars/matrices) of type T
+contained within a single pair interaction densely in memory, with quick access to bonds/Ts
+on any sublattice.
+"""
+struct BondTable{T}
+    bonds         :: Vector{Bond}      # All bonds, sorted on first basis index
+    culled_bonds  :: Vector{Bond}      # Culled to minimal 1/2 bonds, sorted on first basis index
+    data          :: Vector{T}         # Data T associated with each bond in `bonds`
+    culled_data   :: Vector{T}         # Culled data T associated with each bond in `bonds`
+    basis_indices :: Vector{Int}       # Indices to first bond of each basis index in `bonds`
+    function BondTable(bonds::Vector{Vector{Bond}}, data::Vector{Vector{T}}) where {T}
+        (culled_bonds, culled_data) = cull_bonds(bonds, data)
+
+        num_bonds_per_basis = map(length, bonds)
+        basis_indices = cumsum(num_bonds_per_basis) .- length(bonds[1]) .+ 1
+        push!(basis_indices, sum(num_bonds_per_basis) + 1)
+
+        # Flatten everything from Vector{Vector{...}} to Vector{...}
+        bonds = reduce(vcat, bonds)
+        culled_bonds = reduce(vcat, culled_bonds)
+        data = reduce(vcat, data)
+        culled_data = reduce(vcat, culled_data)
+
+        new{T}(bonds, culled_bonds, data, culled_data, basis_indices)
+    end
+end
+
+function Base.show(io::IO, ::MIME"text/plain", bondtable::BondTable{T}) where {T}
+    print(io, "$(length(bondtable))-element, $(length(bondtable.basis_indices)-1)-basis BondTable{$T}")
+end
+
+Base.length(bondtable::BondTable) = length(bondtable.bonds)
+## These functions generate iterators producing (bond, data) for various subsets of bonds ##
+all_bonds(bondtable::BondTable) = zip(bondtable.bonds, bondtable.data)
+culled_bonds(bondtable::BondTable) = zip(bondtable.culled_bonds, bondtable.culled_data)
+function sublat_bonds(bondtable::BondTable, i::Int)
+    @unpack bonds, data, basis_indices = bondtable
+    @boundscheck checkindex(Bool, 1:length(basis_indices)-1, i) ? nothing : throw(BoundsError(bondtable, i))
+    zip(bonds[basis_indices[i]:basis_indices[i+1]-1], data[basis_indices[i]:basis_indices[i+1]-1])
+end
+
+abstract type AbstractPairIntCPU <: AbstractInteractionCPU end
+
+"""
+    HeisenbergCPU <: AbstractPairIntCPU
 
 Implements an exchange interaction which is proportional to
 the identity matrix.
 """
-struct HeisenbergCPU <: InteractionCPU
-    effJ         :: Float64                 # S_i J S_j
-    bonds        :: Vector{Vector{Bond}}    # Each outer Vector is bonds on one sublattice
-    culled_bonds :: Vector{Vector{Bond}}    # Like `bonds`, but culled to the minimal 1/2 bonds
+struct HeisenbergCPU <: AbstractPairIntCPU
+    effJ         :: Float64               # In Heisenberg interaction, all bonds have identical J
+    bondtable    :: BondTable{Float64}    # Bonds store effective J's = S_i J S_j (all identical)
     label        :: String
 end
 
 """
-    DiagonalCouplingCPU
+    DiagonalCouplingCPU <: AbstractPairIntCPU
 
 Implements an exchange interaction where matrices on all bonds
 are diagonal.
 """
-struct DiagonalCouplingCPU <: InteractionCPU
-    effJs         :: Vector{Vector{Vec3}}    # S_i J S_j for each bond
-    culled_effJs  :: Vector{Vector{Vec3}}
-    bonds         :: Vector{Vector{Bond}}    # Each outer Vector is bonds on one sublattice
-    culled_bonds  :: Vector{Vector{Bond}}    # Like `bonds`, but culled to the minimal 1/2 bonds
+struct DiagonalCouplingCPU <: AbstractPairIntCPU
+    bondtable     :: BondTable{Vec3}    # Bonds store diagonal of effective J's = S_i J S_j
     label         :: String
 end
 
 """
-    GeneralCouplingCPU
+    GeneralCouplingCPU <: AbstractPairIntCPU
 
 Implements the most generalized interaction, where matrices on
 all bonds are full 3x3 matrices which vary bond-to-bond.
 """
-struct GeneralCouplingCPU <: InteractionCPU
-    effJs        :: Vector{Vector{Mat3}}    # S_i J S_j for each bond
-    culled_effJs :: Vector{Vector{Mat3}}
-    bonds        :: Vector{Vector{Bond}}    # Each outer Vector is bonds on one sublattice
-    culled_bonds :: Vector{Vector{Bond}}    # Like `bonds`, but culled to the minimal 1/2 bonds
+struct GeneralCouplingCPU <: AbstractPairIntCPU
+    bondtable    :: BondTable{Mat3}    # Bonds store effective J's = S_i J S_j
     label        :: String
 end
-
-const PairInt = Union{HeisenbergCPU, DiagonalCouplingCPU, GeneralCouplingCPU}
 
 # Helper functions producing predicates checking if a matrix is approximately
 # Heisenberg or diagonal
@@ -94,9 +123,13 @@ isdiag(J, tol) = isapprox(diagm(diag(J)), J; atol=tol)
 isheisen(tol) = Base.Fix2(isheisen, tol)
 isdiag(tol) = Base.Fix2(isdiag, tol)
 
-# Figures out the correct maximally-efficient backend type for a quadratic interaction
+# Figures out the correct maximally-efficient backend type for a quadratic interaction, and perform
+#  all of the symmetry propagation.
 function convert_quadratic(int::QuadraticInteraction, cryst::Crystal, sites_info::Vector{SiteInfo}; tol=1e-6)
     @unpack J, bond, label = int
+
+    # Compute the bonds and exchange matrices which live on each basis site
+    # Outer vector corresponds to each basis site, inner vector is all bonds/matrices on that basis site
     sorted_bonds = Vector{Vector{Bond}}()
     sorted_Js = Vector{Vector{Mat3}}()
     for i in 1:nbasis(cryst)
@@ -106,133 +139,130 @@ function convert_quadratic(int::QuadraticInteraction, cryst::Crystal, sites_info
     end
 
     # Product S_i S_j between sites connected by the bond -- same for all bonds in a class
-    # To get interactions quadratic in the unit vectors stored by `SpinSystem`, we store
-    #  (Si J Sj) internally.
+    # To get interactions quadratic in the unit vectors stored by `SpinSystem`, we internally
+    #  store effective exchange matrices (Si J Sj).
     SiSj = sites_info[bond.i].S * sites_info[bond.j].S
     sorted_Js .*= SiSj
 
-    (culled_bonds, culled_Js) = cull_bonds(sorted_bonds, sorted_Js)
-
-    if all(isheisen(tol), Base.Iterators.flatten(culled_Js))
-        return HeisenbergCPU(SiSj * J[1,1], sorted_bonds, culled_bonds, label)
-    elseif all(isdiag(tol), Base.Iterators.flatten(culled_Js))
+    if all(isheisen(tol), Base.Iterators.flatten(sorted_Js))
+        # Pull out the Heisenberg scalar from each exchange matrix
+        scalar_sorted_Js = [
+            [J[1,1] for J in Js]
+            for Js in sorted_Js
+        ]
+        # In the Heisenberg case, all J values are identical -- grab that scalar from the
+        #  first non-empty list.
+        effJ = first(first(
+            Iterators.filter(
+                list_Js->length(list_Js) > 0,
+                scalar_sorted_Js
+            )
+        ))
+        bondtable = BondTable(sorted_bonds, scalar_sorted_Js)
+        return HeisenbergCPU(effJ, bondtable, label)
+    elseif all(isdiag(tol), Base.Iterators.flatten(sorted_Js))
+        # Pull out the diagonal of each exchange matrix
         vec_sorted_Js = [
             [diag(M) for M in Js]
             for Js in sorted_Js
         ]
-        vec_culled_Js = [
-            [diag(M) for M in Js]
-            for Js in culled_Js
-        ]
-        return DiagonalCouplingCPU(
-            vec_sorted_Js, vec_culled_Js,
-            sorted_bonds, culled_bonds, label
-        )
+        bondtable = BondTable(sorted_bonds, vec_sorted_Js)
+        return DiagonalCouplingCPU(bondtable, label)
     else
-        return GeneralCouplingCPU(
-            sorted_Js, culled_Js,
-            sorted_bonds, culled_bonds, label
-        )
+        bondtable = BondTable(sorted_bonds, sorted_Js)
+        return GeneralCouplingCPU(bondtable, label)
     end
 end
 
-function energy(spins::Array{Vec3, 4}, heisenberg::HeisenbergCPU)
-    @unpack effJ, culled_bonds = heisenberg
+function energy(spins::Array{Vec3}, heisenberg::HeisenbergCPU)
+    @unpack effJ, bondtable = heisenberg
     E = 0.0
+
     latsize = size(spins)[2:end]
-    for (i, bonds) in enumerate(culled_bonds)
-        for bond in bonds
-            @unpack j, n = bond
-            for cell in CartesianIndices(latsize)
-                sᵢ = spins[i, cell]
-                sⱼ = spins[j, offset(cell, n, latsize)]
-                E += sᵢ ⋅ sⱼ
-            end
+    for (bond, _) in culled_bonds(bondtable)
+        @unpack i, j, n = bond
+        for cell in CartesianIndices(latsize)
+            sᵢ = spins[i, cell]
+            sⱼ = spins[j, offset(cell, n, latsize)]
+            E += sᵢ ⋅ sⱼ
         end
     end
     return effJ * E
 end
 
-function energy(spins::Array{Vec3, 4}, diag_coup::DiagonalCouplingCPU)
-    @unpack culled_effJs, culled_bonds = diag_coup
+function energy(spins::Array{Vec3}, diag_coup::DiagonalCouplingCPU)
+    bondtable = diag_coup.bondtable
     E = 0.0
+
     latsize = size(spins)[2:end]
-    for (i, (Js, bonds)) in enumerate(zip(culled_effJs, culled_bonds))
-        for (J, bond) in zip(Js, bonds)
-            @unpack j, n = bond
-            for cell in CartesianIndices(latsize)
-                sᵢ = spins[i, cell]
-                sⱼ = spins[j, offset(cell, n, latsize)]
-                E += (J .* sᵢ) ⋅ sⱼ
-            end
+    for (bond, J) in culled_bonds(bondtable)
+        @unpack i, j, n = bond
+        for cell in CartesianIndices(latsize)
+            sᵢ = spins[i, cell]
+            sⱼ = spins[j, offset(cell, n, latsize)]
+            E += (J .* sᵢ) ⋅ sⱼ
         end
     end
     return E
 end
 
-function energy(spins::Array{Vec3, 4}, gen_coup::GeneralCouplingCPU)
-    @unpack culled_effJs, culled_bonds = gen_coup
+function energy(spins::Array{Vec3}, gen_coup::GeneralCouplingCPU)
+    bondtable = gen_coup.bondtable
     E = 0.0
+
     latsize = size(spins)[2:end]
-    for (i, (Js, bonds)) in enumerate(zip(culled_effJs, culled_bonds))
-        for (J, bond) in zip(Js, bonds)
-            @unpack j, n = bond
-            for cell in CartesianIndices(latsize)
-                sᵢ = spins[i, cell]
-                sⱼ = spins[j, offset(cell, n, latsize)]
-                E += dot(sᵢ, J, sⱼ)
-            end
+    for (bond, J) in culled_bonds(bondtable)
+        @unpack i, j, n = bond
+        for cell in CartesianIndices(latsize)
+            sᵢ = spins[i, cell]
+            sⱼ = spins[j, offset(cell, n, latsize)]
+            E += dot(sᵢ, J, sⱼ)
         end
     end
     return E
 end
 
 "Accumulates the local -∇ℋ coming from Heisenberg couplings into `B`"
-@inline function _accum_neggrad!(B::Array{Vec3, 4}, spins::Array{Vec3, 4}, heisen::HeisenbergCPU)
+@inline function _accum_neggrad!(B::Array{Vec3}, spins::Array{Vec3}, heisen::HeisenbergCPU)
+    @unpack effJ, bondtable = heisen
+
     latsize = size(spins)[2:end]
-    @unpack effJ, culled_bonds = heisen
-    for (i, bonds) in enumerate(culled_bonds)
-        for bond in bonds
-            @unpack j, n = bond
-            for cell in CartesianIndices(latsize)
-                offsetcell = offset(cell, n, latsize)
-                B[i, cell] = B[i, cell] - effJ * spins[j, offsetcell]
-                B[j, offsetcell] = B[j, offsetcell] - effJ * spins[i, cell]
-            end
+    for (bond, _) in culled_bonds(bondtable)
+        @unpack i, j, n = bond
+        for cell in CartesianIndices(latsize)
+            offsetcell = offset(cell, n, latsize)
+            B[i, cell] = B[i, cell] - effJ * spins[j, offsetcell]
+            B[j, offsetcell] = B[j, offsetcell] - effJ * spins[i, cell]
         end
     end
 end
 
 "Accumulates the local -∇ℋ coming from diagonal couplings into `B`"
-@inline function _accum_neggrad!(B::Array{Vec3, 4}, spins::Array{Vec3, 4}, diag_coup::DiagonalCouplingCPU)
-    latsize = size(spins)[2:end]
+@inline function _accum_neggrad!(B::Array{Vec3}, spins::Array{Vec3}, diag_coup::DiagonalCouplingCPU)
+    bondtable = diag_coup.bondtable
 
-    @unpack culled_effJs, culled_bonds = diag_coup
-    for (i, (Js, bonds)) in enumerate(zip(culled_effJs, culled_bonds))
-        for (J, bond) in zip(Js, bonds)
-            @unpack j, n = bond
-            for cell in CartesianIndices(latsize)
-                offsetcell = offset(cell, n, latsize)
-                B[i, cell] = B[i, cell] - J .* spins[j, offsetcell]
-                B[j, offsetcell] = B[j, offsetcell] - J .* spins[i, cell]
-            end
+    latsize = size(spins)[2:end]
+    for (bond, J) in culled_bonds(bondtable)
+        @unpack i, j, n = bond
+        for cell in CartesianIndices(latsize)
+            offsetcell = offset(cell, n, latsize)
+            B[i, cell] = B[i, cell] - J .* spins[j, offsetcell]
+            B[j, offsetcell] = B[j, offsetcell] - J .* spins[i, cell]
         end
     end
 end
 
 "Accumulates the local -∇ℋ coming from general couplings into `B`"
-@inline function _accum_neggrad!(B::Array{Vec3, 4}, spins::Array{Vec3, 4}, gen_coup::GeneralCouplingCPU)
-    latsize = size(spins)[2:end]
+@inline function _accum_neggrad!(B::Array{Vec3}, spins::Array{Vec3}, gen_coup::GeneralCouplingCPU)
+    bondtable = gen_coup.bondtable
 
-    @unpack culled_effJs, culled_bonds = gen_coup
-    for (i, (Js, bonds)) in enumerate(zip(culled_effJs, culled_bonds))
-        for (J, bond) in zip(Js, bonds)
-            @unpack j, n = bond
-            for cell in CartesianIndices(latsize)
-                offsetcell = offset(cell, n, latsize)
-                B[i, cell] = B[i, cell] - J * spins[j, offsetcell]
-                B[j, offsetcell] = B[j, offsetcell] - J * spins[i, cell]
-            end
+    latsize = size(spins)[2:end]
+    for (bond, J) in culled_bonds(bondtable)
+        @unpack i, j, n = bond
+        for cell in CartesianIndices(latsize)
+            offsetcell = offset(cell, n, latsize)
+            B[i, cell] = B[i, cell] - J * spins[j, offsetcell]
+            B[j, offsetcell] = B[j, offsetcell] - J * spins[i, cell]
         end
     end
 end

--- a/src/Plotting.jl
+++ b/src/Plotting.jl
@@ -76,12 +76,12 @@ function plot_bonds(lattice::Lattice, ints::Vector{<:AbstractInteractionCPU};
     cent_cell = CartesianIndex(div.(lattice.size .+ 1, 2)...)
     cent_pt = lattice[basis_idx, cent_cell]
     for (n, int) in enumerate(sorted_ints)
-        if !isa(int, PairInt)
+        if !isa(int, AbstractPairIntCPU)
             continue
         end
 
         pts = Vector{GLMakie.Point3f}()
-        for bond in sublat_bonds(int.bondtable, basis_idx)
+        for (bond, _) in sublat_bonds(int.bondtable, basis_idx)
             new_cell = offset(cent_cell, bond.n, lattice.size)
             bond_pt = lattice[bond.j, new_cell]
             push!(pts, GLMakie.Point3f(cent_pt))

--- a/src/Plotting.jl
+++ b/src/Plotting.jl
@@ -49,7 +49,7 @@ draws the points.
 """
 plot_lattice(cryst::Crystal, latsize=(3,3,3); kwargs...) = plot_lattice(Lattice(cryst, latsize); kwargs...)
 
-function plot_bonds(lattice::Lattice, ints::Vector{<:InteractionCPU};
+function plot_bonds(lattice::Lattice, ints::Vector{<:AbstractInteractionCPU};
                     colors=:Dark2_8, bondwidth=4, kwargs...)
     fig, ax = _setup_scene()
 
@@ -61,23 +61,27 @@ function plot_bonds(lattice::Lattice, ints::Vector{<:InteractionCPU};
     # Sort interactions so that longer bonds are plotted first
     sorted_ints = sort(
         ints, 
-        by=int->length(int.bonds[basis_idx]) > 0 ? distance(lattice, first(int.bonds[basis_idx])) : Inf
+        by=int->(
+            iszero(length(int.bondtable))
+            ? Inf 
+            : distance(lattice, first(all_bonds(int.bondtable))[1])
+        )
     )
-
-    toggles = Vector{GLMakie.Toggle}()
-    labels = Vector{GLMakie.Label}()
 
     # Plot the lattice
     plot_lattice!(ax, lattice; kwargs...)
+
+    toggles = Vector{GLMakie.Toggle}()
+    labels = Vector{GLMakie.Label}()
     cent_cell = CartesianIndex(div.(lattice.size .+ 1, 2)...)
     cent_pt = lattice[basis_idx, cent_cell]
-    for (n, int) in enumerate(ints)
+    for (n, int) in enumerate(sorted_ints)
         if !isa(int, PairInt)
             continue
         end
 
         pts = Vector{GLMakie.Point3f}()
-        for bond in int.bonds[basis_idx]
+        for bond in sublat_bonds(int.bondtable, basis_idx)
             new_cell = offset(cent_cell, bond.n, lattice.size)
             bond_pt = lattice[bond.j, new_cell]
             push!(pts, GLMakie.Point3f(cent_pt))
@@ -108,7 +112,8 @@ end
 Plot a list of pair interactions defined on a `Crystal`. `latsize` sets how many
 unit cells are plotted, and `kwargs` are passed to to `plot_lattice!`.
 """
-function plot_bonds(cryst::Crystal, ints::Vector{<:Interaction}, latsize=(3,3,3); kwargs...)
+function plot_bonds(cryst::Crystal, ints::Vector{<:AbstractInteraction}, latsize=(3,3,3);
+                    kwargs...)
     latsize = collect(Int64.(latsize))
     lattice = Lattice(cryst, latsize)
     all_sites_info = propagate_site_info(cryst, SiteInfo[])
@@ -124,7 +129,7 @@ end
 Plot all pair interactions appearing in `sys.hamiltonian`, on the
 underlying crystal lattice. `kwargs` are passed to `plot_lattice!`.
 """
-@inline function plot_bonds(sys::SpinSystem; reduced_cell=true, kwargs...)
+@inline function plot_bonds(sys::SpinSystem; kwargs...)
     ℋ = sys.hamiltonian
     pair_ints = vcat(ℋ.heisenbergs, ℋ.diag_coups, ℋ.gen_coups)
     plot_bonds(sys.lattice, pair_ints; kwargs...)
@@ -157,7 +162,6 @@ function plot_all_bonds(crystal::Crystal, max_dist, latsize=(3,3,3); kwargs...)
             push!(interactions, heisenberg(1.0, bond, label))
         end
     end
-
     @assert length(interactions) > 0 "No non-self interactions found!"
 
     plot_bonds(crystal, interactions, latsize; kwargs...)
@@ -186,7 +190,6 @@ function plot_all_bonds_between(crystal, i, j, max_dist, latsize=(3,3,3); kwargs
             push!(interactions, heisenberg(1.0, bond, label))
         end
     end
-
     @assert length(interactions) > 0 "No non-self interactions found!"
 
     plot_bonds(crystal, interactions, latsize; kwargs...)

--- a/src/Sunny.jl
+++ b/src/Sunny.jl
@@ -69,7 +69,7 @@ export sample!, thermalize!, anneal!
 export running_energy, running_mag, reset_running_energy!, reset_running_mag!
 
 include("Integrators.jl")
-export HeunP, LangevinHeunP, evolve!
+export HeunP, LangevinHeunP, SphericalMidpoint, evolve!
 export LangevinSampler
 
 include("StructureFactors.jl")

--- a/src/Systems.jl
+++ b/src/Systems.jl
@@ -103,7 +103,7 @@ end
 
 
 """
-    SpinSystem(crystal::Crystal, ints::Vector{<:Interaction}, latsize, sites_info::Vector{SiteInfo}=[];
+    SpinSystem(crystal::Crystal, ints::Vector{<:AbstractInteraction}, latsize, sites_info::Vector{SiteInfo}=[];
                μB, μ0)
 
 Construct a `SpinSystem` with spins of magnitude `S` residing on the lattice sites
@@ -112,8 +112,8 @@ Construct a `SpinSystem` with spins of magnitude `S` residing on the lattice sit
  the ``+𝐳̂`` direction. μB and μ0 set the Bohr magneton and vacuum permeability. By
  default, these are set so that the unit system is (meV, T, Å).
 """
-function SpinSystem(crystal::Crystal, ints::Vector{<:Interaction}, latsize, sites_info::Vector{SiteInfo}=SiteInfo[];
-                    μB=BOHR_MAGNETON, μ0=VACUUM_PERM)
+function SpinSystem(crystal::Crystal, ints::Vector{<:AbstractInteraction}, latsize,
+                    sites_info::Vector{SiteInfo}=SiteInfo[]; μB=BOHR_MAGNETON, μ0=VACUUM_PERM)
     latsize = collect(Int64.(latsize))
     lattice = Lattice(crystal, latsize)
 

--- a/test/test_ewald.jl
+++ b/test/test_ewald.jl
@@ -160,7 +160,7 @@ function test_mono_dip_consistent()
               [0.5, 0.5, 0.5]]
     latsize = [2, 2, 2]
     cryst = Crystal(lat_vecs, b_vecs)
-    sys = SpinSystem(cryst, Sunny.Interaction[], latsize)
+    sys = SpinSystem(cryst, Sunny.AbstractInteraction[], latsize)
     rand!(sys)
 
     dip_ewald = Sunny.ewald_sum_dipole(sys.lattice, sys.sites; extent=15)

--- a/test/test_fourier.jl
+++ b/test/test_fourier.jl
@@ -4,7 +4,7 @@
 function test_energy_consistency(crystal, latsize)
     μB = Sunny.BOHR_MAGNETON
     μ0 = Sunny.VACUUM_PERM
-    sys = SpinSystem(crystal, Sunny.Interaction[], latsize; μB, μ0)
+    sys = SpinSystem(crystal, Sunny.AbstractInteraction[], latsize; μB, μ0)
     rand!(sys)
 
     dipdip = dipole_dipole(; extent=5, η=0.5)
@@ -22,7 +22,7 @@ function test_energy_consistency(crystal, latsize)
 end
 
 function test_field_consistency(crystal, latsize)
-    sys = SpinSystem(crystal, Sunny.Interaction[], latsize)
+    sys = SpinSystem(crystal, Sunny.AbstractInteraction[], latsize)
     rand!(sys)
     
     dipdip = dipole_dipole(; extent=4, η=0.5)

--- a/test/test_pair_interactions.jl
+++ b/test/test_pair_interactions.jl
@@ -53,4 +53,47 @@
 
     test_quadratic_shown_info()
 
+    # Checks that a list of bonds contains no equivalent bonds
+    function no_equivalent_bonds(bonds::Vector{Bond})
+        for (i, bond) in enumerate(bonds[1:end-1])
+            equiv_bond = Bond(bond.j, bond.i, -bond.n)
+            rest_of_bonds = bonds[i+1:end]
+            if (bond ∈ rest_of_bonds) || (equiv_bond ∈ rest_of_bonds)
+                return false
+            end
+        end
+        return true
+    end
+
+    # Test that iterating over bonds on specific sublattices both only gives
+    #  bonds of that sublattice, but also that we hit all bonds if we iterate
+    #  over each sublattice.
+    function correct_sublat_iteration(bondtable::Sunny.BondTable)
+        total_iterated = 0
+        for b in 1:nbasis(bondtable)
+            for (bond, _) in Sunny.sublat_bonds(bondtable, b)
+                if !(bond.i == b || bond.j == b)
+                    return false
+                end
+                total_iterated += 1
+            end
+        end
+        return total_iterated == length(bondtable)
+    end
+
+    @testset "BondTable" begin
+        cryst = Sunny.diamond_crystal()
+        latsize = (4, 4, 4)
+        exchange_ints = diamond_test_exchanges()
+        sys = SpinSystem(cryst, exchange_ints, (4,4,4))
+        ℋ = sys.hamiltonian
+        pair_ints = [ℋ.heisenbergs..., ℋ.diag_coups..., ℋ.gen_coups...]
+
+        for pair_int in pair_ints
+            bondtable = pair_int.bondtable
+            @test no_equivalent_bonds(bondtable.culled_bonds)
+            @test correct_sublat_iteration(bondtable)
+        end
+    end
+
 end

--- a/test/test_units.jl
+++ b/test/test_units.jl
@@ -18,60 +18,69 @@ function collect_energy_and_field(int, μB, μ0)
 end
 
 # All exchange interactions should be invariant under μ0, μB changes
-function test_exchanges_scaling(μBs, μ0s)
+function validate_exchanges_scaling(μBs, μ0s)
     exchange_ints = diamond_test_exchanges()
     
     # Check that for all values of μB, μ0, all energies
     #  and fields are unchanged compared to first set of values.
     ref_μB, ref_μ0 = μBs[1], μ0s[1]
-    @testset "Exchange Scaling" begin
-        for int in exchange_ints
-            (ref_E, ref_B) = collect_energy_and_field(int, ref_μB, ref_μ0)
-            for (μB, μ0) in zip(μBs[2:end], μ0s[2:end])
-                (E, B) = collect_energy_and_field(int, μB, μ0)
-                @test E ≈ ref_E
-                @test B ≈ ref_B
-            end
+    for int in exchange_ints
+        (ref_E, ref_B) = collect_energy_and_field(int, ref_μB, ref_μ0)
+        
+        pass = true
+        for (μB, μ0) in zip(μBs[2:end], μ0s[2:end])
+            (E, B) = collect_energy_and_field(int, μB, μ0)
+            pass &= E ≈ ref_E
+            pass &= B ≈ ref_B
         end
+        @test pass
     end
 end
 
 # Zeeman energies/fields should scale linearly with μB, invariant to μ0
-function test_field_scaling(μBs, μ0s)
+function validate_field_scaling(μBs, μ0s)
     ref_μB, ref_μ0 = μBs[1], μ0s[1]
 
     ext_field = external_field(rand(3))
 
     (ref_E, ref_B) = collect_energy_and_field(ext_field, ref_μB, ref_μ0)
-    @testset "Zeeman Scaling" begin
-        for (μB, μ0) in zip(μBs[2:end], μ0s[2:end])
-            (E, B) = collect_energy_and_field(ext_field, μB, μ0)
-            @test E ≈ (μB / ref_μB) * ref_E
-            @test B ≈ (μB / ref_μB) .* ref_B
-        end
+    
+    pass = true
+    for (μB, μ0) in zip(μBs[2:end], μ0s[2:end])
+        (E, B) = collect_energy_and_field(ext_field, μB, μ0)
+        pass &= E ≈ (μB / ref_μB) * ref_E
+        pass &= B ≈ (μB / ref_μB) .* ref_B
     end
+    @test pass
 end
 
 # Dipole-dipole interactions should scale linearly with μ0, and
 #  quadratically with μB
-function test_dipole_scaling(μBs, μ0s)
+function validate_dipole_scaling(μBs, μ0s)
     ref_μB, ref_μ0 = μBs[1], μ0s[1]
 
     dip_dip = dipole_dipole()
     
     (ref_E, ref_B) = collect_energy_and_field(dip_dip, ref_μB, ref_μ0)
-    @testset "Dipole-Dipole Scaling" begin
-        for (μB, μ0) in zip(μBs[2:end], μ0s[2:end])
-            (E, B) = collect_energy_and_field(dip_dip, μB, μ0)
-            @test E ≈ (μ0 / ref_μ0) * (μB / ref_μB)^2 * ref_E
-            @test B ≈ (μ0 / ref_μ0) * (μB / ref_μB)^2 .* ref_B
-        end
+
+    pass = true
+    for (μB, μ0) in zip(μBs[2:end], μ0s[2:end])
+        (E, B) = collect_energy_and_field(dip_dip, μB, μ0)
+        pass &= E ≈ (μ0 / ref_μ0) * (μB / ref_μB)^2 * ref_E
+        pass &= B ≈ (μ0 / ref_μ0) * (μB / ref_μB)^2 .* ref_B
     end
+    @test pass
 end
 
 
 @testset verbose=true "Unit Scaling" begin
-    test_exchanges_scaling(μBs, μ0s)
-    test_field_scaling(μBs, μ0s)
-    test_dipole_scaling(μBs, μ0s)
+    @testset "Exchange Scaling" begin
+        validate_exchanges_scaling(μBs, μ0s)
+    end
+    @testset "Zeeman Scaling" begin
+        validate_field_scaling(μBs, μ0s)
+    end
+    @testset "Dipole-Dipole Scaling" begin
+        validate_dipole_scaling(μBs, μ0s)
+    end
 end


### PR DESCRIPTION
In the previous code generating pair interactions, and using them to compute energies and fields, there was a lot of difficult-to-read code which mucked around with lists of bonds living on different sublattices.

This PR attempts to consolidate all of that logic into a new (internal) type `BondTable`, which exposes simple interfaces for iterating over all bonds, the culled bonds, or just those on a certain sublattice.

An additional goal of this refactor is that a single `Vector{Bond}` is more amenable to being put on the GPU than the `Vector{Vector{Bond}}` we worked with previously. The CUDA kernels I have been working on depend on this linear layout.